### PR TITLE
Update @effect/docgen to v4.0.0-beta.102

### DIFF
--- a/docs/frida-tools/FridaDevice.ts.md
+++ b/docs/frida-tools/FridaDevice.ts.md
@@ -66,7 +66,7 @@ declare const acquireAndroidEmulatorDevice: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L88)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L88)
 
 Since v1.0.0
 
@@ -91,7 +91,7 @@ declare const acquireAndroidEmulatorDeviceConfig: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L109)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L109)
 
 Since v1.0.0
 
@@ -107,7 +107,7 @@ declare const acquireLocalDevice: () => Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L59)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L59)
 
 Since v1.0.0
 
@@ -122,7 +122,7 @@ declare const acquireRemoteDevice: (
 ) => Effect.Effect<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L78)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L78)
 
 Since v1.0.0
 
@@ -136,7 +136,7 @@ declare const acquireUsbDevice: (
 ) => Effect.Effect<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L69)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L69)
 
 Since v1.0.0
 
@@ -156,7 +156,7 @@ declare const DeviceLive: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L227)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L227)
 
 Since v1.0.0
 
@@ -183,7 +183,7 @@ declare const layerAndroidEmulatorDevice: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L156)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L156)
 
 Since v1.0.0
 
@@ -208,7 +208,7 @@ declare const layerAndroidEmulatorDeviceConfig: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L177)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L177)
 
 Since v1.0.0
 
@@ -220,7 +220,7 @@ Since v1.0.0
 declare const layerLocalDevice: Layer.Layer<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L128)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L128)
 
 Since v1.0.0
 
@@ -235,7 +235,7 @@ declare const layerRemoteDevice: (
 ) => Layer.Layer<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L138)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L138)
 
 Since v1.0.0
 
@@ -249,7 +249,7 @@ declare const layerUsbDevice: (
 ) => Layer.Layer<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L148)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L148)
 
 Since v1.0.0
 
@@ -267,7 +267,7 @@ export interface FridaDevice {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L37)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L37)
 
 Since v1.0.0
 
@@ -281,7 +281,7 @@ Since v1.0.0
 declare const isFridaDevice: (u: unknown) => u is FridaDevice
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L53)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L53)
 
 Since v1.0.0
 
@@ -318,7 +318,7 @@ declare const DeviceSchema: Schema.Union<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L196)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L196)
 
 Since v1.0.0
 
@@ -332,7 +332,7 @@ Since v1.0.0
 declare const FridaDevice: Context.Service<FridaDevice, FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L47)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L47)
 
 Since v1.0.0
 
@@ -346,7 +346,7 @@ Since v1.0.0
 declare const FridaDeviceTypeId: unique symbol
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L25)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L25)
 
 Since v1.0.0
 
@@ -358,6 +358,6 @@ Since v1.0.0
 type FridaDeviceTypeId = typeof FridaDeviceTypeId
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L31)
 
 Since v1.0.0

--- a/docs/frida-tools/FridaDeviceAcquisitionError.ts.md
+++ b/docs/frida-tools/FridaDeviceAcquisitionError.ts.md
@@ -29,6 +29,6 @@ Since v1.0.0
 declare class FridaDeviceAcquisitionError
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDeviceAcquisitionError.ts#L13)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDeviceAcquisitionError.ts#L13)
 
 Since v1.0.0

--- a/docs/frida-tools/FridaScript.ts.md
+++ b/docs/frida-tools/FridaScript.ts.md
@@ -53,7 +53,7 @@ declare const compile: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L109)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L109)
 
 Since v1.0.0
 
@@ -83,7 +83,7 @@ declare const load: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L123)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L123)
 
 Since v1.0.0
 
@@ -100,7 +100,7 @@ declare const logWatchErrors: <A, E1, E2, R>(
 ) => Stream.Stream<Exit.Exit<A, E1>, E2, R>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L192)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L192)
 
 Since v1.0.0
 
@@ -132,7 +132,7 @@ declare const watch: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L163)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L163)
 
 Since v1.0.0
 
@@ -156,7 +156,7 @@ declare const layer: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L147)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L147)
 
 Since v1.0.0
 
@@ -191,7 +191,7 @@ export interface FridaScript {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L44)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L44)
 
 Since v1.0.0
 
@@ -225,7 +225,7 @@ export interface LoadOptions extends Frida.ScriptOptions, Frida.CompilerOptions 
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L83)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L83)
 
 Since v1.0.0
 
@@ -239,7 +239,7 @@ Since v1.0.0
 declare const isFridaScript: (u: unknown) => u is FridaScript
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L77)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L77)
 
 Since v1.0.0
 
@@ -253,7 +253,7 @@ Since v1.0.0
 declare const FridaScript: Context.Service<FridaScript, FridaScript>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L71)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L71)
 
 Since v1.0.0
 
@@ -267,7 +267,7 @@ Since v1.0.0
 declare const FridaScriptTypeId: unique symbol
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L32)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L32)
 
 Since v1.0.0
 
@@ -279,6 +279,6 @@ Since v1.0.0
 type FridaScriptTypeId = typeof FridaScriptTypeId
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L38)
 
 Since v1.0.0

--- a/docs/frida-tools/FridaSession.ts.md
+++ b/docs/frida-tools/FridaSession.ts.md
@@ -49,7 +49,7 @@ declare const attach: (
 ) => Effect.Effect<FridaSession, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice | Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L103)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L103)
 
 Since v1.0.0
 
@@ -63,7 +63,7 @@ declare const frontmost: (
 ) => Effect.Effect<Frida.Application, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L85)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L85)
 
 Since v1.0.0
 
@@ -78,7 +78,7 @@ declare const spawn: (
 ) => Effect.Effect<number, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice | Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L94)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L94)
 
 Since v1.0.0
 
@@ -98,7 +98,7 @@ declare const SessionLive: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L159)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L159)
 
 Since v1.0.0
 
@@ -113,7 +113,7 @@ declare const layer: (
 ) => Layer.Layer<FridaSession, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L113)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L113)
 
 Since v1.0.0
 
@@ -127,7 +127,7 @@ declare const layerFrontmost: (
 ) => Layer.Layer<FridaSession, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L122)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L122)
 
 Since v1.0.0
 
@@ -168,7 +168,7 @@ export interface FridaSession {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L40)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L40)
 
 Since v1.0.0
 
@@ -182,7 +182,7 @@ Since v1.0.0
 declare const isFridaSession: (u: unknown) => u is FridaSession
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L79)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L79)
 
 Since v1.0.0
 
@@ -219,7 +219,7 @@ declare const AttachSchema: Schema.Union<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L130)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L130)
 
 Since v1.0.0
 
@@ -233,7 +233,7 @@ Since v1.0.0
 declare const FridaSession: Context.Service<FridaSession, FridaSession>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L73)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L73)
 
 Since v1.0.0
 
@@ -247,7 +247,7 @@ Since v1.0.0
 declare const FridaSessionTypeId: unique symbol
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L28)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L28)
 
 Since v1.0.0
 
@@ -259,6 +259,6 @@ Since v1.0.0
 type FridaSessionTypeId = typeof FridaSessionTypeId
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L34)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L34)
 
 Since v1.0.0

--- a/docs/frida-tools/FridaSessionError.ts.md
+++ b/docs/frida-tools/FridaSessionError.ts.md
@@ -29,6 +29,6 @@ Since v1.0.0
 declare class FridaSessionError
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSessionError.ts#L13)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSessionError.ts#L13)
 
 Since v1.0.0

--- a/docs/frida-tools/index.ts.md
+++ b/docs/frida-tools/index.ts.md
@@ -35,7 +35,7 @@ Re-exports all named exports from the "./FridaDevice.ts" module as `FridaDevice`
 export * as FridaDevice from "./FridaDevice.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L10)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L10)
 
 Since v1.0.0
 
@@ -49,7 +49,7 @@ Re-exports all named exports from the "./FridaDeviceAcquisitionError.ts" module 
 export * as FridaDeviceAcquisitionError from "./FridaDeviceAcquisitionError.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L17)
 
 Since v1.0.0
 
@@ -63,7 +63,7 @@ Re-exports all named exports from the "./FridaScript.ts" module as `FridaScript`
 export * as FridaScript from "./FridaScript.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L24)
 
 Since v1.0.0
 
@@ -77,7 +77,7 @@ Re-exports all named exports from the "./FridaSession.ts" module as `FridaSessio
 export * as FridaSession from "./FridaSession.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L31)
 
 Since v1.0.0
 
@@ -91,6 +91,6 @@ Re-exports all named exports from the "./FridaSessionError.ts" module as `FridaS
 export * as FridaSessionError from "./FridaSessionError.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L38)
 
 Since v1.0.0

--- a/docs/gplayapi/GooglePlayApi.ts.md
+++ b/docs/gplayapi/GooglePlayApi.ts.md
@@ -44,7 +44,7 @@ declare const bulkDetails: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L78)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L78)
 
 Since v1.0.0
 
@@ -68,7 +68,7 @@ declare const delivery: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L137)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L137)
 
 Since v1.0.0
 
@@ -86,7 +86,7 @@ declare const details: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L54)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L54)
 
 Since v1.0.0
 
@@ -120,7 +120,7 @@ declare const downloadToDisk: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L278)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L278)
 
 Since v1.0.0
 
@@ -154,7 +154,7 @@ declare const downloadToStreams: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L173)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L173)
 
 Since v1.0.0
 
@@ -173,7 +173,7 @@ declare const purchase: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L107)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L107)
 
 Since v1.0.0
 
@@ -187,7 +187,7 @@ Since v1.0.0
 declare const AndroidDevice: typeof AndroidDevice
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L41)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L41)
 
 Since v1.0.0
 
@@ -199,6 +199,6 @@ Since v1.0.0
 declare const AndroidDeviceService: typeof AndroidDeviceService
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L47)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L47)
 
 Since v1.0.0

--- a/docs/gplayapi/index.ts.md
+++ b/docs/gplayapi/index.ts.md
@@ -32,6 +32,6 @@ Re-exports all named exports from the "./GooglePlayApi.ts" module as `GooglePlay
 export * as GooglePlayApi from "./GooglePlayApi.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L11)
 
 Since v1.0.0

--- a/docs/il2cpp-bridge/Assembly.ts.md
+++ b/docs/il2cpp-bridge/Assembly.ts.md
@@ -33,7 +33,7 @@ Since v1.0.0
 declare const assembly: (name: string) => Effect.Effect<Il2Cpp.Assembly, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L28)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L28)
 
 Since v1.0.0
 
@@ -49,7 +49,7 @@ declare const assemblyCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L45)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L45)
 
 Since v1.0.0
 
@@ -61,7 +61,7 @@ Since v1.0.0
 declare const attach: Effect.Effect<Il2Cpp.Thread, never, Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L63)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L63)
 
 Since v1.0.0
 
@@ -73,7 +73,7 @@ Since v1.0.0
 declare const tryAssembly: (name: string) => Effect.Effect<Il2Cpp.Assembly, Cause.NoSuchElementError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L35)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L35)
 
 Since v1.0.0
 
@@ -89,7 +89,7 @@ declare const tryAssemblyCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L54)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L54)
 
 Since v1.0.0
 
@@ -103,6 +103,6 @@ Since v1.0.0
 declare const CacheCapacity: Context.Reference<number>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L19)
 
 Since v1.0.0

--- a/docs/il2cpp-bridge/Class.ts.md
+++ b/docs/il2cpp-bridge/Class.ts.md
@@ -46,7 +46,7 @@ Since v1.0.0
 declare const CacheCapacity: Reference<number>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L23)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L23)
 
 Since v1.0.0
 
@@ -60,7 +60,7 @@ Since v1.0.0
 declare const class: ((name: string) => (image: Il2Cpp.Image) => Effect.Effect<Il2Cpp.Class, never, never>) & ((image: Il2Cpp.Image, name: string) => Effect.Effect<Il2Cpp.Class, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L94)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L94)
 
 Since v1.0.0
 
@@ -76,7 +76,7 @@ declare const classCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L115)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L115)
 
 Since v1.0.0
 
@@ -96,7 +96,7 @@ declare const field: ((
   ) => Effect.Effect<Il2Cpp.Field<T>, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L162)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L162)
 
 Since v1.0.0
 
@@ -115,7 +115,7 @@ declare const fieldCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L210)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L210)
 
 Since v1.0.0
 
@@ -127,7 +127,7 @@ Since v1.0.0
 declare const fields: (klass: Il2Cpp.Class) => Effect.Effect<ReadonlyArray<Il2Cpp.Field>, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L155)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L155)
 
 Since v1.0.0
 
@@ -149,7 +149,7 @@ declare const method: ((
   ) => Effect.Effect<Il2Cpp.Method<T>, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L285)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L285)
 
 Since v1.0.0
 
@@ -169,7 +169,7 @@ declare const methodCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L339)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L339)
 
 Since v1.0.0
 
@@ -181,7 +181,7 @@ Since v1.0.0
 declare const methods: (klass: Il2Cpp.Class) => Effect.Effect<ReadonlyArray<Il2Cpp.Method>, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L278)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L278)
 
 Since v1.0.0
 
@@ -194,7 +194,7 @@ declare const nested: ((name: string) => (klass: Il2Cpp.Class) => Effect.Effect<
   ((klass: Il2Cpp.Class, name: string) => Effect.Effect<Il2Cpp.Class, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L403)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L403)
 
 Since v1.0.0
 
@@ -210,7 +210,7 @@ declare const nestedCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L426)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L426)
 
 Since v1.0.0
 
@@ -225,7 +225,7 @@ declare const tryClass: ((
   ((image: Il2Cpp.Image, name: string) => Effect.Effect<Il2Cpp.Class, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L101)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L101)
 
 Since v1.0.0
 
@@ -241,7 +241,7 @@ declare const tryClassCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L128)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L128)
 
 Since v1.0.0
 
@@ -261,7 +261,7 @@ declare const tryField: ((
   ) => Effect.Effect<Il2Cpp.Field<T>, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L184)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L184)
 
 Since v1.0.0
 
@@ -280,7 +280,7 @@ declare const tryFieldCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L244)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L244)
 
 Since v1.0.0
 
@@ -302,7 +302,7 @@ declare const tryMethod: ((
   ) => Effect.Effect<Il2Cpp.Method<T>, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L310)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L310)
 
 Since v1.0.0
 
@@ -322,7 +322,7 @@ declare const tryMethodCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L371)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L371)
 
 Since v1.0.0
 
@@ -337,7 +337,7 @@ declare const tryNested: ((
   ((klass: Il2Cpp.Class, name: string) => Effect.Effect<Il2Cpp.Class, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L412)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L412)
 
 Since v1.0.0
 
@@ -353,6 +353,6 @@ declare const tryNestedCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L439)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L439)
 
 Since v1.0.0

--- a/docs/il2cpp-bridge/Equivalence.ts.md
+++ b/docs/il2cpp-bridge/Equivalence.ts.md
@@ -31,7 +31,7 @@ Since v1.0.0
 declare const class: Equivalence.Equivalence<Il2Cpp.Class>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L31)
 
 Since v1.0.0
 
@@ -43,7 +43,7 @@ Since v1.0.0
 declare const field: Equivalence.Equivalence<Il2Cpp.Field<Il2Cpp.Field.Type>>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L38)
 
 Since v1.0.0
 
@@ -55,7 +55,7 @@ Since v1.0.0
 declare const image: Equivalence.Equivalence<Il2Cpp.Image>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L18)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L18)
 
 Since v1.0.0
 
@@ -67,7 +67,7 @@ Since v1.0.0
 declare const method: Equivalence.Equivalence<Il2Cpp.Method<Il2Cpp.Method.ReturnType>>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L44)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L44)
 
 Since v1.0.0
 
@@ -79,6 +79,6 @@ Since v1.0.0
 declare const nativePointer: Equivalence.Equivalence<NativePointer>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L12)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L12)
 
 Since v1.0.0

--- a/docs/il2cpp-bridge/Extensions.ts.md
+++ b/docs/il2cpp-bridge/Extensions.ts.md
@@ -55,7 +55,7 @@ Since v1.0.0
 declare class Dictionary<K, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L14)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L14)
 
 Since v1.0.0
 
@@ -71,7 +71,7 @@ declare const lift: <K extends Il2Cpp.Field.Type = Il2Cpp.Field.Type, V extends 
 ) => Dictionary<K, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L122)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L122)
 
 ### of (static method)
 
@@ -87,7 +87,7 @@ declare const of: <K extends Il2Cpp.Field.Type = Il2Cpp.Field.Type, V extends Il
 ) => Dictionary<K, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L130)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L130)
 
 ### get (method)
 
@@ -99,7 +99,7 @@ Gets the value by the specified key of the current dictionary.
 declare const get: (key: K) => V
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L45)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L45)
 
 ### set (method)
 
@@ -111,7 +111,7 @@ Sets the pair of the current dictionary.
 declare const set: (key: K, value: V) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L50)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L50)
 
 ### add (method)
 
@@ -123,7 +123,7 @@ Adds a new key to the current dictionary.
 declare const add: (key: K, value: V) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L55)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L55)
 
 ### clear (method)
 
@@ -135,7 +135,7 @@ Clears the current dictionary.
 declare const clear: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L60)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L60)
 
 ### containsKey (method)
 
@@ -147,7 +147,7 @@ Determines if the key is in the current dictionary.
 declare const containsKey: (key: K) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L65)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L65)
 
 ### containsValue (method)
 
@@ -159,7 +159,7 @@ Determines if the value is in the current dictionary.
 declare const containsValue: (value: V) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L70)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L70)
 
 ### find (method)
 
@@ -171,7 +171,7 @@ Finds a key in the current dictionary and returns its index.
 declare const find: (key: K) => number
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L75)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L75)
 
 ### remove (method)
 
@@ -183,7 +183,7 @@ Removes the given key from the current dictionary.
 declare const remove: (key: K) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L80)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L80)
 
 ### [Symbol.iterator] (method)
 
@@ -193,7 +193,7 @@ declare const remove: (key: K) => boolean
 declare const [Symbol.iterator]: () => IterableIterator<[K, V]>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L84)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L84)
 
 ### toString (method)
 
@@ -203,7 +203,7 @@ declare const [Symbol.iterator]: () => IterableIterator<[K, V]>
 declare const toString: () => string
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L91)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L91)
 
 ### toRecord (method)
 
@@ -213,7 +213,7 @@ declare const toString: () => string
 declare const toRecord: (keys?: Array<K> | undefined) => Record<string, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L95)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L95)
 
 ## List (class)
 
@@ -223,7 +223,7 @@ declare const toRecord: (keys?: Array<K> | undefined) => Record<string, V>
 declare class List<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L148)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L148)
 
 Since v1.0.0
 
@@ -237,7 +237,7 @@ Lifts an Il2Cpp.Array to a List.
 declare const lift: <T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type>(object: Il2Cpp.Object) => List<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L233)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L233)
 
 ### of (static method)
 
@@ -252,7 +252,7 @@ declare const of: <T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type>(
 ) => List<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L238)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L238)
 
 ### get (method)
 
@@ -264,7 +264,7 @@ Gets the value by the specified index of the current list.
 declare const get: (index: number) => T
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L163)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L163)
 
 ### set (method)
 
@@ -276,7 +276,7 @@ Sets the element of the current list.
 declare const set: (index: number, value: T) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L168)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L168)
 
 ### add (method)
 
@@ -288,7 +288,7 @@ Adds a new element to the current list.
 declare const add: (item: T) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L173)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L173)
 
 ### clear (method)
 
@@ -300,7 +300,7 @@ Clears the current list.
 declare const clear: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L178)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L178)
 
 ### contains (method)
 
@@ -312,7 +312,7 @@ Determines if the key is in the current list.
 declare const contains: (item: T) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L183)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L183)
 
 ### indexOf (method)
 
@@ -324,7 +324,7 @@ Determines the index of the element of the current list.
 declare const indexOf: (item: T) => number
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L188)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L188)
 
 ### insert (method)
 
@@ -336,7 +336,7 @@ Inserts an element at the given index of the current list.
 declare const insert: (index: number, item: T) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L193)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L193)
 
 ### remove (method)
 
@@ -348,7 +348,7 @@ Removes a data element from the current list.
 declare const remove: (item: T) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L198)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L198)
 
 ### reverse (method)
 
@@ -360,7 +360,7 @@ Reverses the current list.
 declare const reverse: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L203)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L203)
 
 ### sort (method)
 
@@ -372,7 +372,7 @@ Sorts the current list.
 declare const sort: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L208)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L208)
 
 ### [Symbol.iterator] (method)
 
@@ -382,7 +382,7 @@ declare const sort: () => void
 declare const [Symbol.iterator]: () => IterableIterator<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L217)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L217)
 
 ### toString (method)
 
@@ -392,4 +392,4 @@ declare const [Symbol.iterator]: () => IterableIterator<T>
 declare const toString: () => string
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L223)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L223)

--- a/docs/il2cpp-bridge/FridaIl2cppBridge.ts.md
+++ b/docs/il2cpp-bridge/FridaIl2cppBridge.ts.md
@@ -35,6 +35,6 @@ declare const il2cppPerformEffect: ((
   ) => Effect.Effect<X, E, R>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/FridaIl2cppBridge.ts#L16)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/FridaIl2cppBridge.ts#L16)
 
 Since v1.0.0

--- a/docs/il2cpp-bridge/index.ts.md
+++ b/docs/il2cpp-bridge/index.ts.md
@@ -37,7 +37,7 @@ Re-exports all named exports from the "./Assembly.ts" module as `Assembly`.
 export * as Assembly from "./Assembly.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L9)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L9)
 
 Since v1.0.0
 
@@ -53,7 +53,7 @@ Re-exports all named exports from the "./Class.ts" module as `Class`.
 export * as Class from "./Class.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L15)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L15)
 
 Since v1.0.0
 
@@ -69,7 +69,7 @@ Re-exports all named exports from the "./Equivalence.ts" module as `Equivalence`
 export * as Equivalence from "./Equivalence.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L21)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L21)
 
 Since v1.0.0
 
@@ -85,7 +85,7 @@ Re-exports all named exports from the "./Extensions.ts" module as `Extensions`.
 export * as Extensions from "./Extensions.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L27)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L27)
 
 Since v1.0.0
 
@@ -101,6 +101,6 @@ Re-exports all named exports from the "./FridaIl2cppBridge.ts" module as `FridaI
 export * as FridaIl2cppBridge from "./FridaIl2cppBridge.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L33)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L33)
 
 Since v1.0.0

--- a/docs/platform/Channel.ts.md
+++ b/docs/platform/Channel.ts.md
@@ -38,6 +38,6 @@ declare const fromIOStream: <E1, E2>(
 ) => ReturnType<typeof internal.fromIOStream<E1, E2>>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Channel.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Channel.ts#L17)
 
 Since v1.0.0

--- a/docs/platform/FridaRuntime.ts.md
+++ b/docs/platform/FridaRuntime.ts.md
@@ -41,6 +41,6 @@ declare const runMain: (<A, E>(options?: {
   ) => void)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/FridaRuntime.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/FridaRuntime.ts#L19)
 
 Since v1.0.0

--- a/docs/platform/MemoryAccessMonitor.ts.md
+++ b/docs/platform/MemoryAccessMonitor.ts.md
@@ -38,6 +38,6 @@ declare const MemoryAccessMonitorStream: (
 ) => Stream.Stream<MemoryAccessDetails, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/MemoryAccessMonitor.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/MemoryAccessMonitor.ts#L19)
 
 Since v1.0.0

--- a/docs/platform/Sink.ts.md
+++ b/docs/platform/Sink.ts.md
@@ -42,7 +42,7 @@ declare const fromOutputStream: <E>(
 ) => Sink.Sink<void, Uint8Array, never, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L31)
 
 Since v1.0.0
 
@@ -62,7 +62,7 @@ declare const makeUnixOutputStream: <E>(
 ) => Sink.Sink<void, Uint8Array, never, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L42)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L42)
 
 Since v1.0.0
 
@@ -82,7 +82,7 @@ declare const makeWin32OutputStream: <E>(
 ) => Sink.Sink<void, Uint8Array, never, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L53)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L53)
 
 Since v1.0.0
 
@@ -94,7 +94,7 @@ Since v1.0.0
 declare const sendSink: () => Sink.Sink<void, string, never, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L24)
 
 Since v1.0.0
 
@@ -110,6 +110,6 @@ export interface FromWritableOptions {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L16)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L16)
 
 Since v1.0.0

--- a/docs/platform/Socket.ts.md
+++ b/docs/platform/Socket.ts.md
@@ -33,7 +33,7 @@ Connect to a TCP or UNIX server.
 declare const connect: (options: SocketConnectOptions) => Effect.Effect<EffectSocket.Socket, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Socket.ts#L27)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Socket.ts#L27)
 
 Since v1.0.0
 
@@ -51,7 +51,7 @@ declare const liftSocketConnection: (
 ) => Effect.Effect<EffectSocket.Socket, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Socket.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Socket.ts#L17)
 
 Since v1.0.0
 
@@ -69,6 +69,6 @@ declare const listen: (
 ) => Effect.Effect<EffectSocket.Socket, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Socket.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Socket.ts#L38)
 
 Since v1.0.0

--- a/docs/platform/Stream.ts.md
+++ b/docs/platform/Stream.ts.md
@@ -46,7 +46,7 @@ declare const fromInputStream: <E>(
 ) => Stream.Stream<Uint8Array, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L59)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L59)
 
 Since v1.0.0
 
@@ -66,7 +66,7 @@ declare const makeUnixInputStream: <E>(
 ) => Stream.Stream<Uint8Array, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L70)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L70)
 
 Since v1.0.0
 
@@ -86,7 +86,7 @@ declare const makeWin32InputStream: <E>(
 ) => Stream.Stream<Uint8Array, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L81)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L81)
 
 Since v1.0.0
 
@@ -104,7 +104,7 @@ Since v1.0.0
 declare const toInputStream: <E, R>(stream: Stream.Stream<Uint8Array, E, R>) => Effect.Effect<InputStream, never, R>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L92)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L92)
 
 Since v1.0.0
 
@@ -118,7 +118,7 @@ Like `toInputStream` but with `R` fixed to `never`.
 declare const toInputStreamNever: <E>(stream: Stream.Stream<Uint8Array, E, never>) => InputStream
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L101)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L101)
 
 Since v1.0.0
 
@@ -145,7 +145,7 @@ declare const receiveStream: (
 ) => Effect.Effect<Stream.Stream<{ message: string; data?: Uint8Array | undefined }, never, never>, never, Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L28)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L28)
 
 Since v1.0.0
 
@@ -161,6 +161,6 @@ export interface FromInputStreamOptions {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L20)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L20)
 
 Since v1.0.0

--- a/docs/platform/index.ts.md
+++ b/docs/platform/index.ts.md
@@ -36,7 +36,7 @@ Re-exports all named exports from the "./Channel.ts" module as `Channel`.
 export * as Channel from "./Channel.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L10)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L10)
 
 Since v1.0.0
 
@@ -50,7 +50,7 @@ Re-exports all named exports from the "./FridaRuntime.ts" module as `FridaRuntim
 export * as FridaRuntime from "./FridaRuntime.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L17)
 
 Since v1.0.0
 
@@ -64,7 +64,7 @@ Re-exports all named exports from the "./MemoryAccessMonitor.ts" module as `Memo
 export * as MemoryAccessMonitor from "./MemoryAccessMonitor.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L24)
 
 Since v1.0.0
 
@@ -78,7 +78,7 @@ Re-exports all named exports from the "./Sink.ts" module as `Sink`.
 export * as Sink from "./Sink.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L31)
 
 Since v1.0.0
 
@@ -92,7 +92,7 @@ Re-exports all named exports from the "./Socket.ts" module as `Socket`.
 export * as Socket from "./Socket.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L38)
 
 Since v1.0.0
 
@@ -106,6 +106,6 @@ Re-exports all named exports from the "./Stream.ts" module as `Stream`.
 export * as Stream from "./Stream.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L45)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L45)
 
 Since v1.0.0

--- a/docs/rpc/frida/FridaRpcClient.ts.md
+++ b/docs/rpc/frida/FridaRpcClient.ts.md
@@ -36,7 +36,7 @@ declare const layerProtocolFrida: Layer.Layer<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L103)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L103)
 
 Since v1.0.0
 
@@ -54,6 +54,6 @@ declare const makeProtocolFrida: () => Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L27)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L27)
 
 Since v1.0.0

--- a/docs/rpc/frida/FridaRpcServer.ts.md
+++ b/docs/rpc/frida/FridaRpcServer.ts.md
@@ -40,7 +40,7 @@ declare const layerProtocolFrida: (
 ) => Layer.Layer<RpcServer.Protocol, never, RpcSerialization.RpcSerialization>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L161)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L161)
 
 Since v1.0.0
 
@@ -61,7 +61,7 @@ declare const makeProtocolFrida: (
 ) => Effect.Effect<RpcServer.Protocol["Service"], never, RpcSerialization.RpcSerialization>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L136)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L136)
 
 Since v1.0.0
 
@@ -79,6 +79,6 @@ declare const makeProtocolFridaNoSendRecv: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L24)
 
 Since v1.0.0

--- a/docs/rpc/frida/index.ts.md
+++ b/docs/rpc/frida/index.ts.md
@@ -33,7 +33,7 @@ Re-exports all named exports from the "./FridaRpcClient.ts" module as `FridaRpcC
 export * as FridaRpcClient from "./FridaRpcClient.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L11)
 
 Since v1.0.0
 
@@ -47,6 +47,6 @@ Re-exports all named exports from the "./FridaRpcServer.ts" module as `FridaRpcS
 export * as FridaRpcServer from "./FridaRpcServer.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L19)
 
 Since v1.0.0

--- a/docs/rpc/node/FridaRpcClient.ts.md
+++ b/docs/rpc/node/FridaRpcClient.ts.md
@@ -38,7 +38,7 @@ declare const layerProtocolFrida: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L140)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L140)
 
 Since v1.0.0
 
@@ -58,6 +58,6 @@ declare const makeProtocolFrida: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L33)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L33)
 
 Since v1.0.0

--- a/docs/rpc/node/FridaRpcServer.ts.md
+++ b/docs/rpc/node/FridaRpcServer.ts.md
@@ -32,11 +32,11 @@ Since v1.0.0
 declare const layerProtocolFrida: Layer.Layer<
   RpcServer.Protocol,
   never,
-  FridaScript.FridaScript | RpcSerialization.RpcSerialization
+  RpcSerialization.RpcSerialization | FridaScript.FridaScript
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L142)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L142)
 
 Since v1.0.0
 
@@ -54,6 +54,6 @@ declare const makeProtocolFrida: () => Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L30)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L30)
 
 Since v1.0.0

--- a/docs/rpc/node/index.ts.md
+++ b/docs/rpc/node/index.ts.md
@@ -33,7 +33,7 @@ Re-exports all named exports from the "./FridaRpcClient.ts" module as `FridaRpcC
 export * as FridaRpcClient from "./FridaRpcClient.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L11)
 
 Since v1.0.0
 
@@ -47,6 +47,6 @@ Re-exports all named exports from the "./FridaRpcServer.ts" module as `FridaRpcS
 export * as FridaRpcServer from "./FridaRpcServer.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L19)
 
 Since v1.0.0

--- a/docs/sql/FridaSqlClient.ts.md
+++ b/docs/sql/FridaSqlClient.ts.md
@@ -42,7 +42,7 @@ declare const make: (
 ) => Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L102)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L102)
 
 Since v1.0.0
 
@@ -56,7 +56,7 @@ Since v1.0.0
 declare const layer: (config: SqliteClientConfig) => Layer.Layer<SqliteClient | SqlClient.SqlClient, Config.ConfigError>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L270)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L273)
 
 Since v1.0.0
 
@@ -70,7 +70,7 @@ declare const layerConfig: (
 ) => Layer.Layer<SqliteClient | SqlClient.SqlClient, Config.ConfigError>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L256)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L259)
 
 Since v1.0.0
 
@@ -99,7 +99,7 @@ export interface SqliteClient extends SqlClient.SqlClient {
 }
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L49)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L49)
 
 Since v1.0.0
 
@@ -122,7 +122,7 @@ type SqliteClientConfig = (
 }
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L76)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L76)
 
 Since v1.0.0
 
@@ -136,7 +136,7 @@ Since v1.0.0
 declare const SqliteClient: Context.Service<SqliteClient, SqliteClient>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L70)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L70)
 
 Since v1.0.0
 
@@ -150,7 +150,7 @@ Since v1.0.0
 declare const TypeId: unique symbol
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L37)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L37)
 
 Since v1.0.0
 
@@ -162,6 +162,6 @@ Since v1.0.0
 type TypeId = typeof TypeId
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L43)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L43)
 
 Since v1.0.0

--- a/docs/sql/index.ts.md
+++ b/docs/sql/index.ts.md
@@ -31,6 +31,6 @@ Re-exports all named exports from the "./FridaSqlClient.ts" module as `FridaSqlC
 export * as FridaSqlClient from "./FridaSqlClient.ts"
 ```
 
-[Source](/blob/main/src/index.ts#L10)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/index.ts#L10)
 
 Since v1.0.0

--- a/docs/vitest-pool/index.ts.md
+++ b/docs/vitest-pool/index.ts.md
@@ -85,7 +85,7 @@ declare const FridaSchema: Schema.Struct<{
 }>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L31)
 
 Since v1.0.0
 
@@ -101,7 +101,7 @@ declare class FridaPoolWorker {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L40)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L40)
 
 Since v1.0.0
 
@@ -113,7 +113,7 @@ Since v1.0.0
 declare const start: () => Promise<void>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L116)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L117)
 
 ### stop (method)
 
@@ -123,7 +123,7 @@ declare const start: () => Promise<void>
 declare const stop: () => Promise<void>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L122)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L123)
 
 ### send (method)
 
@@ -133,7 +133,7 @@ declare const stop: () => Promise<void>
 declare const send: (message: VitestNode.WorkerRequest) => Promise<void>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L129)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L130)
 
 ### on (method)
 
@@ -143,17 +143,17 @@ declare const send: (message: VitestNode.WorkerRequest) => Promise<void>
 declare const on: (event: string, callback: (arg: any) => void) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L143)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L144)
 
 ### off (method)
 
 **Signature**
 
 ```ts
-declare const off: (_event: string, callback: (arg: any) => void) => void
+declare const off: (event: string, _callback: (arg: any) => void) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L195)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L209)
 
 ### deserialize (method)
 
@@ -163,7 +163,7 @@ declare const off: (_event: string, callback: (arg: any) => void) => void
 declare const deserialize: (data: unknown) => any
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L203)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L213)
 
 ### serialize (method)
 
@@ -173,7 +173,7 @@ declare const deserialize: (data: unknown) => any
 declare const serialize: (data: unknown) => unknown
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L208)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L218)
 
 ### name (property)
 
@@ -183,7 +183,7 @@ declare const serialize: (data: unknown) => unknown
 readonly name: "frida-pool"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L41)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L41)
 
 ## createFridaPool
 
@@ -195,6 +195,6 @@ declare const createFridaPool: (
 ) => VitestNode.PoolRunnerInitializer
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L217)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L227)
 
 Since v1.0.0

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@changesets/cli": "2.31.1",
         "@changesets/config": "3.1.4",
         "@effect/build-utils": "0.8.9",
-        "@effect/docgen": "https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@e57e5f5",
+        "@effect/docgen": "4.0.0-beta.102",
         "@effect/language-service": "0.87.1",
         "@vitest/coverage-v8": "4.1.10",
         "babel-plugin-annotate-pure-calls": "0.5.0",

--- a/packages/create-efffrida-app/docgen.json
+++ b/packages/create-efffrida-app/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/create-efffrida-app/src/",
     "projectHomepage": "https://github.com/leonitousconforti/efffrida/packages/create-efffrida-app",
     "exclude": ["src/*.ts"]
 }

--- a/packages/frida-tools/docgen.json
+++ b/packages/frida-tools/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/",
     "exclude": ["src/internal/**/*.ts"],
     "projectHomepage": "https://github.com/leonitousconforti/efffrida/packages/frida-tools",
     "examplesCompilerOptions": {

--- a/packages/frida-tools/docs/modules/FridaDevice.ts.md
+++ b/packages/frida-tools/docs/modules/FridaDevice.ts.md
@@ -66,7 +66,7 @@ declare const acquireAndroidEmulatorDevice: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L88)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L88)
 
 Since v1.0.0
 
@@ -91,7 +91,7 @@ declare const acquireAndroidEmulatorDeviceConfig: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L109)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L109)
 
 Since v1.0.0
 
@@ -107,7 +107,7 @@ declare const acquireLocalDevice: () => Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L59)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L59)
 
 Since v1.0.0
 
@@ -122,7 +122,7 @@ declare const acquireRemoteDevice: (
 ) => Effect.Effect<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L78)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L78)
 
 Since v1.0.0
 
@@ -136,7 +136,7 @@ declare const acquireUsbDevice: (
 ) => Effect.Effect<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L69)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L69)
 
 Since v1.0.0
 
@@ -156,7 +156,7 @@ declare const DeviceLive: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L227)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L227)
 
 Since v1.0.0
 
@@ -183,7 +183,7 @@ declare const layerAndroidEmulatorDevice: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L156)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L156)
 
 Since v1.0.0
 
@@ -208,7 +208,7 @@ declare const layerAndroidEmulatorDeviceConfig: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L177)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L177)
 
 Since v1.0.0
 
@@ -220,7 +220,7 @@ Since v1.0.0
 declare const layerLocalDevice: Layer.Layer<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L128)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L128)
 
 Since v1.0.0
 
@@ -235,7 +235,7 @@ declare const layerRemoteDevice: (
 ) => Layer.Layer<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L138)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L138)
 
 Since v1.0.0
 
@@ -249,7 +249,7 @@ declare const layerUsbDevice: (
 ) => Layer.Layer<FridaDevice, FridaDeviceAcquisitionError.FridaDeviceAcquisitionError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L148)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L148)
 
 Since v1.0.0
 
@@ -267,7 +267,7 @@ export interface FridaDevice {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L37)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L37)
 
 Since v1.0.0
 
@@ -281,7 +281,7 @@ Since v1.0.0
 declare const isFridaDevice: (u: unknown) => u is FridaDevice
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L53)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L53)
 
 Since v1.0.0
 
@@ -318,7 +318,7 @@ declare const DeviceSchema: Schema.Union<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L196)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L196)
 
 Since v1.0.0
 
@@ -332,7 +332,7 @@ Since v1.0.0
 declare const FridaDevice: Context.Service<FridaDevice, FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L47)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L47)
 
 Since v1.0.0
 
@@ -346,7 +346,7 @@ Since v1.0.0
 declare const FridaDeviceTypeId: unique symbol
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L25)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L25)
 
 Since v1.0.0
 
@@ -358,6 +358,6 @@ Since v1.0.0
 type FridaDeviceTypeId = typeof FridaDeviceTypeId
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDevice.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDevice.ts#L31)
 
 Since v1.0.0

--- a/packages/frida-tools/docs/modules/FridaDeviceAcquisitionError.ts.md
+++ b/packages/frida-tools/docs/modules/FridaDeviceAcquisitionError.ts.md
@@ -29,6 +29,6 @@ Since v1.0.0
 declare class FridaDeviceAcquisitionError
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaDeviceAcquisitionError.ts#L13)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaDeviceAcquisitionError.ts#L13)
 
 Since v1.0.0

--- a/packages/frida-tools/docs/modules/FridaScript.ts.md
+++ b/packages/frida-tools/docs/modules/FridaScript.ts.md
@@ -53,7 +53,7 @@ declare const compile: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L109)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L109)
 
 Since v1.0.0
 
@@ -83,7 +83,7 @@ declare const load: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L123)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L123)
 
 Since v1.0.0
 
@@ -100,7 +100,7 @@ declare const logWatchErrors: <A, E1, E2, R>(
 ) => Stream.Stream<Exit.Exit<A, E1>, E2, R>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L192)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L192)
 
 Since v1.0.0
 
@@ -132,7 +132,7 @@ declare const watch: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L163)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L163)
 
 Since v1.0.0
 
@@ -156,7 +156,7 @@ declare const layer: {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L147)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L147)
 
 Since v1.0.0
 
@@ -191,7 +191,7 @@ export interface FridaScript {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L44)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L44)
 
 Since v1.0.0
 
@@ -225,7 +225,7 @@ export interface LoadOptions extends Frida.ScriptOptions, Frida.CompilerOptions 
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L83)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L83)
 
 Since v1.0.0
 
@@ -239,7 +239,7 @@ Since v1.0.0
 declare const isFridaScript: (u: unknown) => u is FridaScript
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L77)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L77)
 
 Since v1.0.0
 
@@ -253,7 +253,7 @@ Since v1.0.0
 declare const FridaScript: Context.Service<FridaScript, FridaScript>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L71)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L71)
 
 Since v1.0.0
 
@@ -267,7 +267,7 @@ Since v1.0.0
 declare const FridaScriptTypeId: unique symbol
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L32)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L32)
 
 Since v1.0.0
 
@@ -279,6 +279,6 @@ Since v1.0.0
 type FridaScriptTypeId = typeof FridaScriptTypeId
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaScript.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaScript.ts#L38)
 
 Since v1.0.0

--- a/packages/frida-tools/docs/modules/FridaSession.ts.md
+++ b/packages/frida-tools/docs/modules/FridaSession.ts.md
@@ -49,7 +49,7 @@ declare const attach: (
 ) => Effect.Effect<FridaSession, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice | Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L103)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L103)
 
 Since v1.0.0
 
@@ -63,7 +63,7 @@ declare const frontmost: (
 ) => Effect.Effect<Frida.Application, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L85)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L85)
 
 Since v1.0.0
 
@@ -78,7 +78,7 @@ declare const spawn: (
 ) => Effect.Effect<number, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice | Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L94)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L94)
 
 Since v1.0.0
 
@@ -98,7 +98,7 @@ declare const SessionLive: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L159)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L159)
 
 Since v1.0.0
 
@@ -113,7 +113,7 @@ declare const layer: (
 ) => Layer.Layer<FridaSession, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L113)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L113)
 
 Since v1.0.0
 
@@ -127,7 +127,7 @@ declare const layerFrontmost: (
 ) => Layer.Layer<FridaSession, FridaSessionError.FridaSessionError, FridaDevice.FridaDevice>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L122)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L122)
 
 Since v1.0.0
 
@@ -168,7 +168,7 @@ export interface FridaSession {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L40)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L40)
 
 Since v1.0.0
 
@@ -182,7 +182,7 @@ Since v1.0.0
 declare const isFridaSession: (u: unknown) => u is FridaSession
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L79)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L79)
 
 Since v1.0.0
 
@@ -219,7 +219,7 @@ declare const AttachSchema: Schema.Union<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L130)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L130)
 
 Since v1.0.0
 
@@ -233,7 +233,7 @@ Since v1.0.0
 declare const FridaSession: Context.Service<FridaSession, FridaSession>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L73)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L73)
 
 Since v1.0.0
 
@@ -247,7 +247,7 @@ Since v1.0.0
 declare const FridaSessionTypeId: unique symbol
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L28)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L28)
 
 Since v1.0.0
 
@@ -259,6 +259,6 @@ Since v1.0.0
 type FridaSessionTypeId = typeof FridaSessionTypeId
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSession.ts#L34)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSession.ts#L34)
 
 Since v1.0.0

--- a/packages/frida-tools/docs/modules/FridaSessionError.ts.md
+++ b/packages/frida-tools/docs/modules/FridaSessionError.ts.md
@@ -29,6 +29,6 @@ Since v1.0.0
 declare class FridaSessionError
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/FridaSessionError.ts#L13)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/FridaSessionError.ts#L13)
 
 Since v1.0.0

--- a/packages/frida-tools/docs/modules/index.ts.md
+++ b/packages/frida-tools/docs/modules/index.ts.md
@@ -35,7 +35,7 @@ Re-exports all named exports from the "./FridaDevice.ts" module as `FridaDevice`
 export * as FridaDevice from "./FridaDevice.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L10)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L10)
 
 Since v1.0.0
 
@@ -49,7 +49,7 @@ Re-exports all named exports from the "./FridaDeviceAcquisitionError.ts" module 
 export * as FridaDeviceAcquisitionError from "./FridaDeviceAcquisitionError.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L17)
 
 Since v1.0.0
 
@@ -63,7 +63,7 @@ Re-exports all named exports from the "./FridaScript.ts" module as `FridaScript`
 export * as FridaScript from "./FridaScript.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L24)
 
 Since v1.0.0
 
@@ -77,7 +77,7 @@ Re-exports all named exports from the "./FridaSession.ts" module as `FridaSessio
 export * as FridaSession from "./FridaSession.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L31)
 
 Since v1.0.0
 
@@ -91,6 +91,6 @@ Re-exports all named exports from the "./FridaSessionError.ts" module as `FridaS
 export * as FridaSessionError from "./FridaSessionError.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/frida-tools/blob/main/src/index.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/frida-tools/src/index.ts#L38)
 
 Since v1.0.0

--- a/packages/gplayapi/docgen.json
+++ b/packages/gplayapi/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/",
     "exclude": ["src/internal/**/*.ts", "src/generated/**/*.ts"],
     "projectHomepage": "https://github.com/leonitousconforti/efffrida/packages/gplayapi",
     "examplesCompilerOptions": {

--- a/packages/gplayapi/docs/modules/GooglePlayApi.ts.md
+++ b/packages/gplayapi/docs/modules/GooglePlayApi.ts.md
@@ -44,7 +44,7 @@ declare const bulkDetails: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L78)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L78)
 
 Since v1.0.0
 
@@ -68,7 +68,7 @@ declare const delivery: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L137)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L137)
 
 Since v1.0.0
 
@@ -86,7 +86,7 @@ declare const details: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L54)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L54)
 
 Since v1.0.0
 
@@ -120,7 +120,7 @@ declare const downloadToDisk: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L278)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L278)
 
 Since v1.0.0
 
@@ -154,7 +154,7 @@ declare const downloadToStreams: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L173)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L173)
 
 Since v1.0.0
 
@@ -173,7 +173,7 @@ declare const purchase: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L107)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L107)
 
 Since v1.0.0
 
@@ -187,7 +187,7 @@ Since v1.0.0
 declare const AndroidDevice: typeof AndroidDevice
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L41)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L41)
 
 Since v1.0.0
 
@@ -199,6 +199,6 @@ Since v1.0.0
 declare const AndroidDeviceService: typeof AndroidDeviceService
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/GooglePlayApi.ts#L47)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L47)
 
 Since v1.0.0

--- a/packages/gplayapi/docs/modules/index.ts.md
+++ b/packages/gplayapi/docs/modules/index.ts.md
@@ -32,6 +32,6 @@ Re-exports all named exports from the "./GooglePlayApi.ts" module as `GooglePlay
 export * as GooglePlayApi from "./GooglePlayApi.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/gplayapi/blob/main/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L11)
 
 Since v1.0.0

--- a/packages/il2cpp-bridge/docgen.json
+++ b/packages/il2cpp-bridge/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/",
     "exclude": ["src/internal/**/*.ts"],
     "projectHomepage": "https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge",
     "examplesCompilerOptions": {

--- a/packages/il2cpp-bridge/docs/modules/Assembly.ts.md
+++ b/packages/il2cpp-bridge/docs/modules/Assembly.ts.md
@@ -33,7 +33,7 @@ Since v1.0.0
 declare const assembly: (name: string) => Effect.Effect<Il2Cpp.Assembly, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L28)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L28)
 
 Since v1.0.0
 
@@ -49,7 +49,7 @@ declare const assemblyCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L45)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L45)
 
 Since v1.0.0
 
@@ -61,7 +61,7 @@ Since v1.0.0
 declare const attach: Effect.Effect<Il2Cpp.Thread, never, Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L63)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L63)
 
 Since v1.0.0
 
@@ -73,7 +73,7 @@ Since v1.0.0
 declare const tryAssembly: (name: string) => Effect.Effect<Il2Cpp.Assembly, Cause.NoSuchElementError, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L35)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L35)
 
 Since v1.0.0
 
@@ -89,7 +89,7 @@ declare const tryAssemblyCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L54)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L54)
 
 Since v1.0.0
 
@@ -103,6 +103,6 @@ Since v1.0.0
 declare const CacheCapacity: Context.Reference<number>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Assembly.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Assembly.ts#L19)
 
 Since v1.0.0

--- a/packages/il2cpp-bridge/docs/modules/Class.ts.md
+++ b/packages/il2cpp-bridge/docs/modules/Class.ts.md
@@ -46,7 +46,7 @@ Since v1.0.0
 declare const CacheCapacity: Reference<number>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L23)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L23)
 
 Since v1.0.0
 
@@ -60,7 +60,7 @@ Since v1.0.0
 declare const class: ((name: string) => (image: Il2Cpp.Image) => Effect.Effect<Il2Cpp.Class, never, never>) & ((image: Il2Cpp.Image, name: string) => Effect.Effect<Il2Cpp.Class, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L94)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L94)
 
 Since v1.0.0
 
@@ -76,7 +76,7 @@ declare const classCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L115)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L115)
 
 Since v1.0.0
 
@@ -96,7 +96,7 @@ declare const field: ((
   ) => Effect.Effect<Il2Cpp.Field<T>, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L162)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L162)
 
 Since v1.0.0
 
@@ -115,7 +115,7 @@ declare const fieldCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L210)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L210)
 
 Since v1.0.0
 
@@ -127,7 +127,7 @@ Since v1.0.0
 declare const fields: (klass: Il2Cpp.Class) => Effect.Effect<ReadonlyArray<Il2Cpp.Field>, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L155)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L155)
 
 Since v1.0.0
 
@@ -149,7 +149,7 @@ declare const method: ((
   ) => Effect.Effect<Il2Cpp.Method<T>, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L285)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L285)
 
 Since v1.0.0
 
@@ -169,7 +169,7 @@ declare const methodCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L339)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L339)
 
 Since v1.0.0
 
@@ -181,7 +181,7 @@ Since v1.0.0
 declare const methods: (klass: Il2Cpp.Class) => Effect.Effect<ReadonlyArray<Il2Cpp.Method>, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L278)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L278)
 
 Since v1.0.0
 
@@ -194,7 +194,7 @@ declare const nested: ((name: string) => (klass: Il2Cpp.Class) => Effect.Effect<
   ((klass: Il2Cpp.Class, name: string) => Effect.Effect<Il2Cpp.Class, never, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L403)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L403)
 
 Since v1.0.0
 
@@ -210,7 +210,7 @@ declare const nestedCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L426)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L426)
 
 Since v1.0.0
 
@@ -225,7 +225,7 @@ declare const tryClass: ((
   ((image: Il2Cpp.Image, name: string) => Effect.Effect<Il2Cpp.Class, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L101)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L101)
 
 Since v1.0.0
 
@@ -241,7 +241,7 @@ declare const tryClassCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L128)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L128)
 
 Since v1.0.0
 
@@ -261,7 +261,7 @@ declare const tryField: ((
   ) => Effect.Effect<Il2Cpp.Field<T>, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L184)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L184)
 
 Since v1.0.0
 
@@ -280,7 +280,7 @@ declare const tryFieldCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L244)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L244)
 
 Since v1.0.0
 
@@ -302,7 +302,7 @@ declare const tryMethod: ((
   ) => Effect.Effect<Il2Cpp.Method<T>, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L310)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L310)
 
 Since v1.0.0
 
@@ -322,7 +322,7 @@ declare const tryMethodCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L371)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L371)
 
 Since v1.0.0
 
@@ -337,7 +337,7 @@ declare const tryNested: ((
   ((klass: Il2Cpp.Class, name: string) => Effect.Effect<Il2Cpp.Class, Cause.NoSuchElementError, never>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L412)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L412)
 
 Since v1.0.0
 
@@ -353,6 +353,6 @@ declare const tryNestedCached: Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Class.ts#L439)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Class.ts#L439)
 
 Since v1.0.0

--- a/packages/il2cpp-bridge/docs/modules/Equivalence.ts.md
+++ b/packages/il2cpp-bridge/docs/modules/Equivalence.ts.md
@@ -31,7 +31,7 @@ Since v1.0.0
 declare const class: Equivalence.Equivalence<Il2Cpp.Class>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L31)
 
 Since v1.0.0
 
@@ -43,7 +43,7 @@ Since v1.0.0
 declare const field: Equivalence.Equivalence<Il2Cpp.Field<Il2Cpp.Field.Type>>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L38)
 
 Since v1.0.0
 
@@ -55,7 +55,7 @@ Since v1.0.0
 declare const image: Equivalence.Equivalence<Il2Cpp.Image>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L18)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L18)
 
 Since v1.0.0
 
@@ -67,7 +67,7 @@ Since v1.0.0
 declare const method: Equivalence.Equivalence<Il2Cpp.Method<Il2Cpp.Method.ReturnType>>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L44)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L44)
 
 Since v1.0.0
 
@@ -79,6 +79,6 @@ Since v1.0.0
 declare const nativePointer: Equivalence.Equivalence<NativePointer>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Equivalence.ts#L12)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Equivalence.ts#L12)
 
 Since v1.0.0

--- a/packages/il2cpp-bridge/docs/modules/Extensions.ts.md
+++ b/packages/il2cpp-bridge/docs/modules/Extensions.ts.md
@@ -55,7 +55,7 @@ Since v1.0.0
 declare class Dictionary<K, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L14)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L14)
 
 Since v1.0.0
 
@@ -71,7 +71,7 @@ declare const lift: <K extends Il2Cpp.Field.Type = Il2Cpp.Field.Type, V extends 
 ) => Dictionary<K, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L122)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L122)
 
 ### of (static method)
 
@@ -87,7 +87,7 @@ declare const of: <K extends Il2Cpp.Field.Type = Il2Cpp.Field.Type, V extends Il
 ) => Dictionary<K, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L130)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L130)
 
 ### get (method)
 
@@ -99,7 +99,7 @@ Gets the value by the specified key of the current dictionary.
 declare const get: (key: K) => V
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L45)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L45)
 
 ### set (method)
 
@@ -111,7 +111,7 @@ Sets the pair of the current dictionary.
 declare const set: (key: K, value: V) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L50)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L50)
 
 ### add (method)
 
@@ -123,7 +123,7 @@ Adds a new key to the current dictionary.
 declare const add: (key: K, value: V) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L55)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L55)
 
 ### clear (method)
 
@@ -135,7 +135,7 @@ Clears the current dictionary.
 declare const clear: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L60)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L60)
 
 ### containsKey (method)
 
@@ -147,7 +147,7 @@ Determines if the key is in the current dictionary.
 declare const containsKey: (key: K) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L65)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L65)
 
 ### containsValue (method)
 
@@ -159,7 +159,7 @@ Determines if the value is in the current dictionary.
 declare const containsValue: (value: V) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L70)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L70)
 
 ### find (method)
 
@@ -171,7 +171,7 @@ Finds a key in the current dictionary and returns its index.
 declare const find: (key: K) => number
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L75)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L75)
 
 ### remove (method)
 
@@ -183,7 +183,7 @@ Removes the given key from the current dictionary.
 declare const remove: (key: K) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L80)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L80)
 
 ### [Symbol.iterator] (method)
 
@@ -193,7 +193,7 @@ declare const remove: (key: K) => boolean
 declare const [Symbol.iterator]: () => IterableIterator<[K, V]>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L84)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L84)
 
 ### toString (method)
 
@@ -203,7 +203,7 @@ declare const [Symbol.iterator]: () => IterableIterator<[K, V]>
 declare const toString: () => string
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L91)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L91)
 
 ### toRecord (method)
 
@@ -213,7 +213,7 @@ declare const toString: () => string
 declare const toRecord: (keys?: Array<K> | undefined) => Record<string, V>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L95)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L95)
 
 ## List (class)
 
@@ -223,7 +223,7 @@ declare const toRecord: (keys?: Array<K> | undefined) => Record<string, V>
 declare class List<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L148)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L148)
 
 Since v1.0.0
 
@@ -237,7 +237,7 @@ Lifts an Il2Cpp.Array to a List.
 declare const lift: <T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type>(object: Il2Cpp.Object) => List<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L233)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L233)
 
 ### of (static method)
 
@@ -252,7 +252,7 @@ declare const of: <T extends Il2Cpp.Field.Type = Il2Cpp.Field.Type>(
 ) => List<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L238)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L238)
 
 ### get (method)
 
@@ -264,7 +264,7 @@ Gets the value by the specified index of the current list.
 declare const get: (index: number) => T
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L163)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L163)
 
 ### set (method)
 
@@ -276,7 +276,7 @@ Sets the element of the current list.
 declare const set: (index: number, value: T) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L168)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L168)
 
 ### add (method)
 
@@ -288,7 +288,7 @@ Adds a new element to the current list.
 declare const add: (item: T) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L173)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L173)
 
 ### clear (method)
 
@@ -300,7 +300,7 @@ Clears the current list.
 declare const clear: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L178)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L178)
 
 ### contains (method)
 
@@ -312,7 +312,7 @@ Determines if the key is in the current list.
 declare const contains: (item: T) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L183)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L183)
 
 ### indexOf (method)
 
@@ -324,7 +324,7 @@ Determines the index of the element of the current list.
 declare const indexOf: (item: T) => number
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L188)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L188)
 
 ### insert (method)
 
@@ -336,7 +336,7 @@ Inserts an element at the given index of the current list.
 declare const insert: (index: number, item: T) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L193)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L193)
 
 ### remove (method)
 
@@ -348,7 +348,7 @@ Removes a data element from the current list.
 declare const remove: (item: T) => boolean
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L198)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L198)
 
 ### reverse (method)
 
@@ -360,7 +360,7 @@ Reverses the current list.
 declare const reverse: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L203)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L203)
 
 ### sort (method)
 
@@ -372,7 +372,7 @@ Sorts the current list.
 declare const sort: () => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L208)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L208)
 
 ### [Symbol.iterator] (method)
 
@@ -382,7 +382,7 @@ declare const sort: () => void
 declare const [Symbol.iterator]: () => IterableIterator<T>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L217)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L217)
 
 ### toString (method)
 
@@ -392,4 +392,4 @@ declare const [Symbol.iterator]: () => IterableIterator<T>
 declare const toString: () => string
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/Extensions.ts#L223)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/Extensions.ts#L223)

--- a/packages/il2cpp-bridge/docs/modules/FridaIl2cppBridge.ts.md
+++ b/packages/il2cpp-bridge/docs/modules/FridaIl2cppBridge.ts.md
@@ -35,6 +35,6 @@ declare const il2cppPerformEffect: ((
   ) => Effect.Effect<X, E, R>)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/FridaIl2cppBridge.ts#L16)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/FridaIl2cppBridge.ts#L16)
 
 Since v1.0.0

--- a/packages/il2cpp-bridge/docs/modules/index.ts.md
+++ b/packages/il2cpp-bridge/docs/modules/index.ts.md
@@ -37,7 +37,7 @@ Re-exports all named exports from the "./Assembly.ts" module as `Assembly`.
 export * as Assembly from "./Assembly.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L9)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L9)
 
 Since v1.0.0
 
@@ -53,7 +53,7 @@ Re-exports all named exports from the "./Class.ts" module as `Class`.
 export * as Class from "./Class.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L15)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L15)
 
 Since v1.0.0
 
@@ -69,7 +69,7 @@ Re-exports all named exports from the "./Equivalence.ts" module as `Equivalence`
 export * as Equivalence from "./Equivalence.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L21)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L21)
 
 Since v1.0.0
 
@@ -85,7 +85,7 @@ Re-exports all named exports from the "./Extensions.ts" module as `Extensions`.
 export * as Extensions from "./Extensions.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L27)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L27)
 
 Since v1.0.0
 
@@ -101,6 +101,6 @@ Re-exports all named exports from the "./FridaIl2cppBridge.ts" module as `FridaI
 export * as FridaIl2cppBridge from "./FridaIl2cppBridge.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/il2cpp-bridge/blob/main/src/index.ts#L33)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/il2cpp-bridge/src/index.ts#L33)
 
 Since v1.0.0

--- a/packages/platform/docgen.json
+++ b/packages/platform/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/",
     "exclude": ["src/internal/**/*.ts"],
     "projectHomepage": "https://github.com/leonitousconforti/efffrida/packages/platform",
     "examplesCompilerOptions": {

--- a/packages/platform/docs/modules/Channel.ts.md
+++ b/packages/platform/docs/modules/Channel.ts.md
@@ -38,6 +38,6 @@ declare const fromIOStream: <E1, E2>(
 ) => ReturnType<typeof internal.fromIOStream<E1, E2>>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Channel.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Channel.ts#L17)
 
 Since v1.0.0

--- a/packages/platform/docs/modules/FridaRuntime.ts.md
+++ b/packages/platform/docs/modules/FridaRuntime.ts.md
@@ -41,6 +41,6 @@ declare const runMain: (<A, E>(options?: {
   ) => void)
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/FridaRuntime.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/FridaRuntime.ts#L19)
 
 Since v1.0.0

--- a/packages/platform/docs/modules/MemoryAccessMonitor.ts.md
+++ b/packages/platform/docs/modules/MemoryAccessMonitor.ts.md
@@ -38,6 +38,6 @@ declare const MemoryAccessMonitorStream: (
 ) => Stream.Stream<MemoryAccessDetails, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/MemoryAccessMonitor.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/MemoryAccessMonitor.ts#L19)
 
 Since v1.0.0

--- a/packages/platform/docs/modules/Sink.ts.md
+++ b/packages/platform/docs/modules/Sink.ts.md
@@ -42,7 +42,7 @@ declare const fromOutputStream: <E>(
 ) => Sink.Sink<void, Uint8Array, never, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L31)
 
 Since v1.0.0
 
@@ -62,7 +62,7 @@ declare const makeUnixOutputStream: <E>(
 ) => Sink.Sink<void, Uint8Array, never, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L42)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L42)
 
 Since v1.0.0
 
@@ -82,7 +82,7 @@ declare const makeWin32OutputStream: <E>(
 ) => Sink.Sink<void, Uint8Array, never, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L53)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L53)
 
 Since v1.0.0
 
@@ -94,7 +94,7 @@ Since v1.0.0
 declare const sendSink: () => Sink.Sink<void, string, never, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L24)
 
 Since v1.0.0
 
@@ -110,6 +110,6 @@ export interface FromWritableOptions {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Sink.ts#L16)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Sink.ts#L16)
 
 Since v1.0.0

--- a/packages/platform/docs/modules/Socket.ts.md
+++ b/packages/platform/docs/modules/Socket.ts.md
@@ -33,7 +33,7 @@ Connect to a TCP or UNIX server.
 declare const connect: (options: SocketConnectOptions) => Effect.Effect<EffectSocket.Socket, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Socket.ts#L27)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Socket.ts#L27)
 
 Since v1.0.0
 
@@ -51,7 +51,7 @@ declare const liftSocketConnection: (
 ) => Effect.Effect<EffectSocket.Socket, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Socket.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Socket.ts#L17)
 
 Since v1.0.0
 
@@ -69,6 +69,6 @@ declare const listen: (
 ) => Effect.Effect<EffectSocket.Socket, never, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Socket.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Socket.ts#L38)
 
 Since v1.0.0

--- a/packages/platform/docs/modules/Stream.ts.md
+++ b/packages/platform/docs/modules/Stream.ts.md
@@ -46,7 +46,7 @@ declare const fromInputStream: <E>(
 ) => Stream.Stream<Uint8Array, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L59)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L59)
 
 Since v1.0.0
 
@@ -66,7 +66,7 @@ declare const makeUnixInputStream: <E>(
 ) => Stream.Stream<Uint8Array, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L70)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L70)
 
 Since v1.0.0
 
@@ -86,7 +86,7 @@ declare const makeWin32InputStream: <E>(
 ) => Stream.Stream<Uint8Array, E, never>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L81)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L81)
 
 Since v1.0.0
 
@@ -104,7 +104,7 @@ Since v1.0.0
 declare const toInputStream: <E, R>(stream: Stream.Stream<Uint8Array, E, R>) => Effect.Effect<InputStream, never, R>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L92)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L92)
 
 Since v1.0.0
 
@@ -118,7 +118,7 @@ Like `toInputStream` but with `R` fixed to `never`.
 declare const toInputStreamNever: <E>(stream: Stream.Stream<Uint8Array, E, never>) => InputStream
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L101)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L101)
 
 Since v1.0.0
 
@@ -145,7 +145,7 @@ declare const receiveStream: (
 ) => Effect.Effect<Stream.Stream<{ message: string; data?: Uint8Array | undefined }, never, never>, never, Scope.Scope>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L28)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L28)
 
 Since v1.0.0
 
@@ -161,6 +161,6 @@ export interface FromInputStreamOptions {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/Stream.ts#L20)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/Stream.ts#L20)
 
 Since v1.0.0

--- a/packages/platform/docs/modules/index.ts.md
+++ b/packages/platform/docs/modules/index.ts.md
@@ -36,7 +36,7 @@ Re-exports all named exports from the "./Channel.ts" module as `Channel`.
 export * as Channel from "./Channel.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L10)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L10)
 
 Since v1.0.0
 
@@ -50,7 +50,7 @@ Re-exports all named exports from the "./FridaRuntime.ts" module as `FridaRuntim
 export * as FridaRuntime from "./FridaRuntime.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L17)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L17)
 
 Since v1.0.0
 
@@ -64,7 +64,7 @@ Re-exports all named exports from the "./MemoryAccessMonitor.ts" module as `Memo
 export * as MemoryAccessMonitor from "./MemoryAccessMonitor.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L24)
 
 Since v1.0.0
 
@@ -78,7 +78,7 @@ Re-exports all named exports from the "./Sink.ts" module as `Sink`.
 export * as Sink from "./Sink.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L31)
 
 Since v1.0.0
 
@@ -92,7 +92,7 @@ Re-exports all named exports from the "./Socket.ts" module as `Socket`.
 export * as Socket from "./Socket.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L38)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L38)
 
 Since v1.0.0
 
@@ -106,6 +106,6 @@ Re-exports all named exports from the "./Stream.ts" module as `Stream`.
 export * as Stream from "./Stream.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/platform/blob/main/src/index.ts#L45)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/platform/src/index.ts#L45)
 
 Since v1.0.0

--- a/packages/polyfills/docgen.json
+++ b/packages/polyfills/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/polyfills/src/",
     "exclude": ["src/*.ts"],
     "projectHomepage": ""
 }

--- a/packages/rpc/docgen.json
+++ b/packages/rpc/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/",
     "exclude": ["src/internal/**/*.ts", "src/shared/**/*.ts"],
     "projectHomepage": "https://github.com/leonitousconforti/efffrida/packages/rpc",
     "examplesCompilerOptions": {

--- a/packages/rpc/docs/modules/frida/FridaRpcClient.ts.md
+++ b/packages/rpc/docs/modules/frida/FridaRpcClient.ts.md
@@ -36,7 +36,7 @@ declare const layerProtocolFrida: Layer.Layer<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L103)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L103)
 
 Since v1.0.0
 
@@ -54,6 +54,6 @@ declare const makeProtocolFrida: () => Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L27)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L27)
 
 Since v1.0.0

--- a/packages/rpc/docs/modules/frida/FridaRpcServer.ts.md
+++ b/packages/rpc/docs/modules/frida/FridaRpcServer.ts.md
@@ -40,7 +40,7 @@ declare const layerProtocolFrida: (
 ) => Layer.Layer<RpcServer.Protocol, never, RpcSerialization.RpcSerialization>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L161)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L161)
 
 Since v1.0.0
 
@@ -61,7 +61,7 @@ declare const makeProtocolFrida: (
 ) => Effect.Effect<RpcServer.Protocol["Service"], never, RpcSerialization.RpcSerialization>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L136)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L136)
 
 Since v1.0.0
 
@@ -79,6 +79,6 @@ declare const makeProtocolFridaNoSendRecv: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L24)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L24)
 
 Since v1.0.0

--- a/packages/rpc/docs/modules/frida/index.ts.md
+++ b/packages/rpc/docs/modules/frida/index.ts.md
@@ -33,7 +33,7 @@ Re-exports all named exports from the "./FridaRpcClient.ts" module as `FridaRpcC
 export * as FridaRpcClient from "./FridaRpcClient.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L11)
 
 Since v1.0.0
 
@@ -47,6 +47,6 @@ Re-exports all named exports from the "./FridaRpcServer.ts" module as `FridaRpcS
 export * as FridaRpcServer from "./FridaRpcServer.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L19)
 
 Since v1.0.0

--- a/packages/rpc/docs/modules/node/FridaRpcClient.ts.md
+++ b/packages/rpc/docs/modules/node/FridaRpcClient.ts.md
@@ -38,7 +38,7 @@ declare const layerProtocolFrida: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L140)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L140)
 
 Since v1.0.0
 
@@ -58,6 +58,6 @@ declare const makeProtocolFrida: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcClient.ts#L33)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcClient.ts#L33)
 
 Since v1.0.0

--- a/packages/rpc/docs/modules/node/FridaRpcServer.ts.md
+++ b/packages/rpc/docs/modules/node/FridaRpcServer.ts.md
@@ -32,11 +32,11 @@ Since v1.0.0
 declare const layerProtocolFrida: Layer.Layer<
   RpcServer.Protocol,
   never,
-  FridaScript.FridaScript | RpcSerialization.RpcSerialization
+  RpcSerialization.RpcSerialization | FridaScript.FridaScript
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L142)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L142)
 
 Since v1.0.0
 
@@ -54,6 +54,6 @@ declare const makeProtocolFrida: () => Effect.Effect<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/FridaRpcServer.ts#L30)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/FridaRpcServer.ts#L30)
 
 Since v1.0.0

--- a/packages/rpc/docs/modules/node/index.ts.md
+++ b/packages/rpc/docs/modules/node/index.ts.md
@@ -33,7 +33,7 @@ Re-exports all named exports from the "./FridaRpcClient.ts" module as `FridaRpcC
 export * as FridaRpcClient from "./FridaRpcClient.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L11)
 
 Since v1.0.0
 
@@ -47,6 +47,6 @@ Re-exports all named exports from the "./FridaRpcServer.ts" module as `FridaRpcS
 export * as FridaRpcServer from "./FridaRpcServer.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/packages/rpc/blob/main/src/index.ts#L19)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/rpc/src/index.ts#L19)
 
 Since v1.0.0

--- a/packages/sql/docgen.json
+++ b/packages/sql/docgen.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/",
     "exclude": ["src/internal/**/*.ts"],
     "projectHomepage": ""
 }

--- a/packages/sql/docs/modules/FridaSqlClient.ts.md
+++ b/packages/sql/docs/modules/FridaSqlClient.ts.md
@@ -42,7 +42,7 @@ declare const make: (
 ) => Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L102)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L102)
 
 Since v1.0.0
 
@@ -56,7 +56,7 @@ Since v1.0.0
 declare const layer: (config: SqliteClientConfig) => Layer.Layer<SqliteClient | SqlClient.SqlClient, Config.ConfigError>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L270)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L273)
 
 Since v1.0.0
 
@@ -70,7 +70,7 @@ declare const layerConfig: (
 ) => Layer.Layer<SqliteClient | SqlClient.SqlClient, Config.ConfigError>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L256)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L259)
 
 Since v1.0.0
 
@@ -99,7 +99,7 @@ export interface SqliteClient extends SqlClient.SqlClient {
 }
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L49)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L49)
 
 Since v1.0.0
 
@@ -122,7 +122,7 @@ type SqliteClientConfig = (
 }
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L76)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L76)
 
 Since v1.0.0
 
@@ -136,7 +136,7 @@ Since v1.0.0
 declare const SqliteClient: Context.Service<SqliteClient, SqliteClient>
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L70)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L70)
 
 Since v1.0.0
 
@@ -150,7 +150,7 @@ Since v1.0.0
 declare const TypeId: unique symbol
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L37)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L37)
 
 Since v1.0.0
 
@@ -162,6 +162,6 @@ Since v1.0.0
 type TypeId = typeof TypeId
 ```
 
-[Source](/blob/main/src/FridaSqlClient.ts#L43)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/FridaSqlClient.ts#L43)
 
 Since v1.0.0

--- a/packages/sql/docs/modules/index.ts.md
+++ b/packages/sql/docs/modules/index.ts.md
@@ -31,6 +31,6 @@ Re-exports all named exports from the "./FridaSqlClient.ts" module as `FridaSqlC
 export * as FridaSqlClient from "./FridaSqlClient.ts"
 ```
 
-[Source](/blob/main/src/index.ts#L10)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/sql/src/index.ts#L10)
 
 Since v1.0.0

--- a/packages/vitest-pool/docgen.json
+++ b/packages/vitest-pool/docgen.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../node_modules/@effect/docgen/schema.json",
+    "srcLink": "https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/"
+}

--- a/packages/vitest-pool/docs/modules/index.ts.md
+++ b/packages/vitest-pool/docs/modules/index.ts.md
@@ -85,7 +85,7 @@ declare const FridaSchema: Schema.Struct<{
 }>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L31)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L31)
 
 Since v1.0.0
 
@@ -101,7 +101,7 @@ declare class FridaPoolWorker {
 }
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L40)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L40)
 
 Since v1.0.0
 
@@ -113,7 +113,7 @@ Since v1.0.0
 declare const start: () => Promise<void>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L116)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L117)
 
 ### stop (method)
 
@@ -123,7 +123,7 @@ declare const start: () => Promise<void>
 declare const stop: () => Promise<void>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L122)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L123)
 
 ### send (method)
 
@@ -133,7 +133,7 @@ declare const stop: () => Promise<void>
 declare const send: (message: VitestNode.WorkerRequest) => Promise<void>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L129)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L130)
 
 ### on (method)
 
@@ -143,17 +143,17 @@ declare const send: (message: VitestNode.WorkerRequest) => Promise<void>
 declare const on: (event: string, callback: (arg: any) => void) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L143)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L144)
 
 ### off (method)
 
 **Signature**
 
 ```ts
-declare const off: (_event: string, callback: (arg: any) => void) => void
+declare const off: (event: string, _callback: (arg: any) => void) => void
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L195)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L209)
 
 ### deserialize (method)
 
@@ -163,7 +163,7 @@ declare const off: (_event: string, callback: (arg: any) => void) => void
 declare const deserialize: (data: unknown) => any
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L203)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L213)
 
 ### serialize (method)
 
@@ -173,7 +173,7 @@ declare const deserialize: (data: unknown) => any
 declare const serialize: (data: unknown) => unknown
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L208)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L218)
 
 ### name (property)
 
@@ -183,7 +183,7 @@ declare const serialize: (data: unknown) => unknown
 readonly name: "frida-pool"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L41)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L41)
 
 ## createFridaPool
 
@@ -195,6 +195,6 @@ declare const createFridaPool: (
 ) => VitestNode.PoolRunnerInitializer
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/src/index.ts#L217)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/vitest-pool/src/index.ts#L227)
 
 Since v1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: 0.8.9
         version: 0.8.9
       '@effect/docgen':
-        specifier: https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@e57e5f5
-        version: https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@e57e5f5(tsx@4.23.1)(typescript@6.0.3)
+        specifier: 4.0.0-beta.102
+        version: 4.0.0-beta.102(tsx@4.23.1)(typescript@6.0.3)
       '@effect/language-service':
         specifier: 0.87.1
         version: 0.87.1
@@ -737,13 +737,12 @@ packages:
     engines: {node: '>=16.17.1'}
     hasBin: true
 
-  '@effect/docgen@https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@e57e5f5':
-    resolution: {integrity: sha512-DIHhD5hKwbeZDACeG+6r+ARde2MrFMYe49PLyz+YXVhObtr+ENdpsLk/BsMFjEPX0QxrMZJXf8uWFYNFaRUwfw==, tarball: https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@e57e5f5}
-    version: 0.5.2
+  '@effect/docgen@4.0.0-beta.102':
+    resolution: {integrity: sha512-6Xoqr2EJ5ZFKX5NvFID6Zw6XSD4ihnwyBqLeru0LA3grG8W4CjVesByefry2mqQ5YER4ZzX3nHq3jUpN6NnSHg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
-      tsx: ^4.19.3
+      tsx: '>=4.19.3 <5.0.0'
       typescript: 6.0.3
 
   '@effect/language-service@0.87.1':
@@ -1106,10 +1105,6 @@ packages:
 
   '@ioredis/commands@1.10.0':
     resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
-
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
-    engines: {node: '>=18'}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -1690,6 +1685,9 @@ packages:
     resolution: {integrity: sha512-w071DSzP94YfN6XiWhOxnLpYT3uqtxJBDYdh6Jdjzt+Ce6DNspJsPQgpC7rbts/B8tEkq0LHoYuIF/O5Jh5rPg==}
     engines: {node: '>=18'}
 
+  '@ts-morph/common@0.28.1':
+    resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -1929,6 +1927,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
@@ -1962,6 +1964,9 @@ packages:
   cluster-key-slot@1.1.1:
     resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
     engines: {node: '>=0.10.0'}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2260,10 +2265,6 @@ packages:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
     engines: {node: '>=0.10.0'}
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   frida-il2cpp-bridge@0.13.1:
     resolution: {integrity: sha512-qXjdcdI+KM5wnjCwqZTe/Tas/2pClXpDhcVWjiaQFxzSun+1vaoHEWlnMe4F09Vdz/vGkkjFOPKfvDem2A8UOQ==}
     hasBin: true
@@ -2314,12 +2315,6 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
-
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -2489,10 +2484,6 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
-
-  jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
-    engines: {node: 20 || >=22}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -2880,6 +2871,9 @@ packages:
   parse-ms@2.1.0:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3324,6 +3318,20 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  ts-morph@27.0.2:
+    resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
+
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    deprecated: unmaintained
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -3854,15 +3862,24 @@ snapshots:
       micromatch: 4.0.8
       pkg-entry-points: 1.1.2
 
-  '@effect/docgen@https://pkg.pr.new/Effect-TS/docgen/@effect/docgen@e57e5f5(tsx@4.23.1)(typescript@6.0.3)':
+  '@effect/docgen@4.0.0-beta.102(tsx@4.23.1)(typescript@6.0.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@effect/markdown-toc': 0.1.0
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      chalk: 5.6.2
       doctrine: 3.0.0
-      glob: 11.1.0
+      effect: 4.0.0-beta.102
+      glob: 13.0.6
       prettier: 3.9.6
+      ts-morph: 27.0.2
+      tsconfck: 3.1.6(typescript@6.0.3)
       tsx: 4.23.1
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - ioredis
+      - utf-8-validate
 
   '@effect/language-service@0.87.1': {}
 
@@ -3886,6 +3903,16 @@ snapshots:
       '@types/ws': 8.18.1
       effect: 4.0.0-beta.102
       ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102)':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-beta.102(effect@4.0.0-beta.102)
+      effect: 4.0.0-beta.102
+      mime: 4.1.0
+      undici: 8.9.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4094,8 +4121,6 @@ snapshots:
       iconv-lite: 0.7.3
 
   '@ioredis/commands@1.10.0': {}
-
-  '@isaacs/cliui@9.0.0': {}
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -4435,6 +4460,12 @@ snapshots:
       '@ts-graphviz/ast': 2.0.7
       '@ts-graphviz/common': 2.1.5
 
+  '@ts-morph/common@0.28.1':
+    dependencies:
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.17
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -4720,6 +4751,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   chardet@2.2.0: {}
 
   chokidar@3.6.0:
@@ -4752,6 +4785,8 @@ snapshots:
   clone@1.0.4: {}
 
   cluster-key-slot@1.1.1: {}
+
+  code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -5094,11 +5129,6 @@ snapshots:
 
   for-in@1.0.2: {}
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   frida-il2cpp-bridge@0.13.1: {}
 
   frida@17.16.4:
@@ -5144,15 +5174,6 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@11.1.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.2.3
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
@@ -5311,10 +5332,6 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@4.2.3:
-    dependencies:
-      '@isaacs/cliui': 9.0.0
 
   joycon@3.1.1: {}
 
@@ -5688,6 +5705,8 @@ snapshots:
       quansync: 0.2.11
 
   parse-ms@2.1.0: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
@@ -6138,6 +6157,15 @@ snapshots:
       '@ts-graphviz/core': 2.0.7
 
   ts-interface-checker@0.1.13: {}
+
+  ts-morph@27.0.2:
+    dependencies:
+      '@ts-morph/common': 0.28.1
+      code-block-writer: 13.0.3
+
+  tsconfck@3.1.6(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   tsconfig-paths@4.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,5 +35,3 @@ overrides:
 peerDependencyRules:
   allowedVersions:
     typescript: "6.0.3"
-  ignoreMissing:
-    - ioredis

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,3 +35,5 @@ overrides:
 peerDependencyRules:
   allowedVersions:
     typescript: "6.0.3"
+  ignoreMissing:
+    - ioredis


### PR DESCRIPTION
Switches `@effect/docgen` from the pkg.pr.new snapshot (`e57e5f5`) to the published `4.0.0-beta.102` (npm `beta` dist-tag), matching the Effect v4 beta line used elsewhere in the repo.

## Changes

- **`package.json`**: `@effect/docgen` → `4.0.0-beta.102`
- **`pnpm-workspace.yaml`**: added `peerDependencyRules.ignoreMissing: [ioredis]` — the beta's `@effect/platform-node@4.0.0-beta.102` dependency declares a required `ioredis` peer which isn't needed for docgen, and the workspace runs with `strictPeerDependencies: true`
- **`packages/*/docgen.json`**: set the new `srcLink` option to `https://github.com/leonitousconforti/efffrida/blob/main/packages/<pkg>/src/` in every package (plus a new minimal config for `vitest-pool`). Source links were previously broken — either relative (`/blob/main/src/...`) or missing the `packages/<pkg>` path segment — and now resolve to real files on GitHub
- **Docs**: regenerated via `pnpm docgen`

## Known limitation

The beta's printer appends only the file *basename* to `srcLink` (`Printer.js` uses `sourceFile.getBaseName()`), so the rpc package's nested modules (`src/frida/`, `src/node/`) link one directory too high (e.g. `packages/rpc/src/FridaRpcClient.ts` instead of `packages/rpc/src/frida/FridaRpcClient.ts`). Not fixable via config; needs an upstream fix in Effect-TS/docgen.

## Verification

- `pnpm install` — clean
- `pnpm docgen` — all packages succeed
- `pnpm lint` — passes