### PR TITLE
cap renovate memory usage on mend-hosted runners

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,13 @@
     "nix": {
         "enabled": true
     },
+    "toolSettings": {
+        "nodeMaxMemory": 1024
+    },
+    "env": {
+        "PNPM_WORKERS": "2",
+        "PNPM_MAX_WORKERS": "2"
+    },
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": ["before 5am on monday"],


### PR DESCRIPTION
Renovate has been failing with `kernel-out-of-memory` on the Mend developer dashboard since 2026-08-03, the last successful run being hours after pnpm went to 11.18.0 in #159. No successful run since.

pnpm 11 raised default network concurrency from 1-16 workers to 16-64 (pnpm/pnpm#10215), which pushes `pnpm install --lockfile-only --recursive` past the 3 GB Mend-hosted job limit. See renovatebot/renovate#40942 and renovatebot/renovate#43072.

`nodeMaxMemory` only bounds the Node parent process, not pnpm's worker subprocesses, so it is set low deliberately to leave headroom for the workers inside the 3 GB. `PNPM_WORKERS`/`PNPM_MAX_WORKERS` cap the workers themselves.

If this still OOMs, try `nodeMaxMemory: 1536`. If it flips to a JS heap error instead, the parent process has become the constraint rather than the workers.