### PR TITLE
fix: serialize pnpm install scripts to avoid tsgo patch race

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,11 @@ hoistWorkspacePackages: false
 preferWorkspacePackages: true
 resolvePeersFromWorkspaceRoot: false
 
+# The root and both templates all run `effect-tsgo patch` in their `prepare`
+# script, and they all resolve to the same physical typescript install. Running
+# them concurrently races on the binary swap, so keep install scripts serial.
+childConcurrency: 1
+
 packages:
   - packages/*
   - scratchpad


### PR DESCRIPTION
Fixes the `pnpm install` failure on `main` ([run 31110018850](https://github.com/leonitousconforti/efffrida/actions/runs/31110018850)):

```
templates/agent-only prepare: ERROR (#1): PatcherError: Transaction destination already exists:
  .../node_modules/.pnpm/@typescript+typescript-linux-x64@7.0.2/.../lib/tsc.original
```

## Cause

The root and both templates declare `"prepare": "effect-tsgo patch"`, and all three resolve typescript 7.0.2 to the same physical directory in `node_modules/.pnpm`. pnpm runs importer prepare hooks with `childConcurrency: 5`, so all three pass tsgo's "already patched" check before any of them performs the `tsc` to `tsc.original` rename, and the losers fail.

It is a race, which is why e0ca730 (#174) passed with identical config and d559b0a (#175) failed.

## Fix

`childConcurrency: 1` serializes the hooks, so the root patches and the templates skip:

```
. prepare: Patched typescript at .../lib/tsc
templates/agent-only prepare: typescript skipped because backup already exists
templates/app-and-agent prepare: typescript skipped because backup already exists
```

The templates keep their own `prepare` script because `create-efffrida-app` copies those directories verbatim, so a scaffolded standalone project still needs to patch.

Tradeoff: this serializes all install scripts, not just the tsgo ones. Locally it made no measurable difference (2.4s install). The alternative is asking upstream for `effect-tsgo patch` to lock or tolerate a concurrent patch.

## Verification

Install had aborted the run before any other step executed, so all CI steps were run locally: `clean`, `codegen`, `docgen`, the `packages/**/src` diff check, `check`, `circular`, `lint`, `build` all exit 0, and `test` is 13 passed / 4 skipped.