### PR TITLE
Break AndroidDevice out of GooglePlayApi into its own module

### DIFF
--- a/.changeset/olive-pandas-attack.md
+++ b/.changeset/olive-pandas-attack.md
@@ -6,4 +6,4 @@ Break `AndroidDevice` out of `GooglePlayApi` into its own `AndroidDevice` module
 
 `GooglePlayApi.AndroidDevice` and `GooglePlayApi.AndroidDeviceService` are no longer exported. Import them from the new module instead, either through the package index (`import { AndroidDevice } from "@efffrida/gplayapi"`) or through the subpath (`import * as AndroidDevice from "@efffrida/gplayapi/AndroidDevice"`).
 
-The `EmbeddedPixel7aLive` layer also moved from a static on the `AndroidDevice` class to a top level export of the new module: `AndroidDevice.EmbeddedPixel7aLive`.
+The statics on the `AndroidDevice` class also moved to top level exports of the new module: `AndroidDevice.fromPropertiesFile`, `AndroidDevice.EmbeddedPixel7a`, and `AndroidDevice.EmbeddedPixel7aLive`.

--- a/.changeset/olive-pandas-attack.md
+++ b/.changeset/olive-pandas-attack.md
@@ -1,0 +1,7 @@
+---
+"@efffrida/gplayapi": patch
+---
+
+Break `AndroidDevice` out of `GooglePlayApi` into its own `AndroidDevice` module, mirroring the `PlayAccount` module.
+
+`GooglePlayApi.AndroidDevice` and `GooglePlayApi.AndroidDeviceService` are no longer exported. Import them from the new module instead, either through the package index (`import { AndroidDevice } from "@efffrida/gplayapi"`) or through the subpath (`import * as AndroidDevice from "@efffrida/gplayapi/AndroidDevice"`).

--- a/.changeset/olive-pandas-attack.md
+++ b/.changeset/olive-pandas-attack.md
@@ -5,3 +5,5 @@
 Break `AndroidDevice` out of `GooglePlayApi` into its own `AndroidDevice` module, mirroring the `PlayAccount` module.
 
 `GooglePlayApi.AndroidDevice` and `GooglePlayApi.AndroidDeviceService` are no longer exported. Import them from the new module instead, either through the package index (`import { AndroidDevice } from "@efffrida/gplayapi"`) or through the subpath (`import * as AndroidDevice from "@efffrida/gplayapi/AndroidDevice"`).
+
+The `EmbeddedPixel7aLive` layer also moved from a static on the `AndroidDevice` class to a top level export of the new module: `AndroidDevice.EmbeddedPixel7aLive`.

--- a/docs/gplayapi/AndroidDevice.ts.md
+++ b/docs/gplayapi/AndroidDevice.ts.md
@@ -16,6 +16,8 @@ Since v1.0.0
 
 - [Constants](#constants)
   - [authHeadersTtl](#authheadersttl)
+- [Layers](#layers)
+  - [EmbeddedPixel7aLive](#embeddedpixel7alive)
 - [Models](#models)
   - [AndroidDevice (class)](#androiddevice-class)
     - [authHeaders (property)](#authheaders-property)
@@ -39,6 +41,24 @@ declare const authHeadersTtl: Duration.Duration
 ```
 
 [Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L55)
+
+Since v1.0.0
+
+# Layers
+
+## EmbeddedPixel7aLive
+
+**Signature**
+
+```ts
+declare const EmbeddedPixel7aLive: Layer.Layer<
+  AndroidDeviceService,
+  Schema.SchemaError | PlatformError.PlatformError | PlatformError.BadArgument,
+  FileSystem.FileSystem | Path.Path
+>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L202)
 
 Since v1.0.0
 
@@ -66,7 +86,7 @@ Since v1.0.0
 readonly authHeaders: Effect.Effect<Record<string, string>, HttpClientError.HttpClientError | Schema.SchemaError | PlayAccountError, PlayAccount | HttpClient.HttpClient>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L176)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L170)
 
 Since v1.0.0
 

--- a/docs/gplayapi/AndroidDevice.ts.md
+++ b/docs/gplayapi/AndroidDevice.ts.md
@@ -1,0 +1,85 @@
+---
+title: AndroidDevice.ts
+nav_order: 1
+parent: "@efffrida/gplayapi"
+---
+
+## AndroidDevice.ts overview
+
+Google play android device profiles.
+
+Since v1.0.0
+
+---
+
+## Exports Grouped by Category
+
+- [Constants](#constants)
+  - [authHeadersTtl](#authheadersttl)
+- [Models](#models)
+  - [AndroidDevice (class)](#androiddevice-class)
+    - [authHeaders (property)](#authheaders-property)
+- [Tags](#tags)
+  - [AndroidDeviceService (class)](#androiddeviceservice-class)
+
+---
+
+# Constants
+
+## authHeadersTtl
+
+How long resolved auth headers stay usable. Google's oauth tokens live for an
+hour, so re-acquiring well inside that window keeps a long lived process from
+ever reaching for headers that expired underneath it.
+
+**Signature**
+
+```ts
+declare const authHeadersTtl: Duration.Duration
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L55)
+
+Since v1.0.0
+
+# Models
+
+## AndroidDevice (class)
+
+The profile of the android device that google play requests are made as.
+
+**Signature**
+
+```ts
+declare class AndroidDevice
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L63)
+
+Since v1.0.0
+
+### authHeaders (property)
+
+**Signature**
+
+```ts
+readonly authHeaders: Effect.Effect<Record<string, string>, HttpClientError.HttpClientError | Schema.SchemaError | PlayAccountError, PlayAccount | HttpClient.HttpClient>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L176)
+
+Since v1.0.0
+
+# Tags
+
+## AndroidDeviceService (class)
+
+**Signature**
+
+```ts
+declare class AndroidDeviceService
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L43)
+
+Since v1.0.0

--- a/docs/gplayapi/AndroidDevice.ts.md
+++ b/docs/gplayapi/AndroidDevice.ts.md
@@ -16,6 +16,9 @@ Since v1.0.0
 
 - [Constants](#constants)
   - [authHeadersTtl](#authheadersttl)
+- [Constructors](#constructors)
+  - [EmbeddedPixel7a](#embeddedpixel7a)
+  - [fromPropertiesFile](#frompropertiesfile)
 - [Layers](#layers)
   - [EmbeddedPixel7aLive](#embeddedpixel7alive)
 - [Models](#models)
@@ -44,6 +47,38 @@ declare const authHeadersTtl: Duration.Duration
 
 Since v1.0.0
 
+# Constructors
+
+## EmbeddedPixel7a
+
+**Signature**
+
+```ts
+declare const EmbeddedPixel7a: Effect.Effect<
+  AndroidDevice,
+  Schema.SchemaError | PlatformError.PlatformError | PlatformError.BadArgument,
+  FileSystem.FileSystem | Path.Path
+>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L193)
+
+Since v1.0.0
+
+## fromPropertiesFile
+
+**Signature**
+
+```ts
+declare const fromPropertiesFile: (
+  file: string
+) => Effect.Effect<AndroidDevice, Schema.SchemaError | PlatformError.PlatformError, FileSystem.FileSystem>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L167)
+
+Since v1.0.0
+
 # Layers
 
 ## EmbeddedPixel7aLive
@@ -58,7 +93,7 @@ declare const EmbeddedPixel7aLive: Layer.Layer<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L202)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L206)
 
 Since v1.0.0
 
@@ -86,7 +121,7 @@ Since v1.0.0
 readonly authHeaders: Effect.Effect<Record<string, string>, HttpClientError.HttpClientError | Schema.SchemaError | PlayAccountError, PlayAccount | HttpClient.HttpClient>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L170)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L135)
 
 Since v1.0.0
 

--- a/docs/gplayapi/GooglePlayApi.ts.md
+++ b/docs/gplayapi/GooglePlayApi.ts.md
@@ -1,6 +1,6 @@
 ---
 title: GooglePlayApi.ts
-nav_order: 1
+nav_order: 2
 parent: "@efffrida/gplayapi"
 ---
 
@@ -22,9 +22,6 @@ Since v1.0.0
   - [downloadToDisk](#downloadtodisk)
   - [downloadToStreams](#downloadtostreams)
   - [purchase](#purchase)
-- [Device](#device)
-  - [AndroidDevice](#androiddevice)
-  - [AndroidDeviceService](#androiddeviceservice)
 
 ---
 
@@ -44,7 +41,7 @@ declare const bulkDetails: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L113)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L99)
 
 Since v1.0.0
 
@@ -68,7 +65,7 @@ declare const delivery: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L172)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L158)
 
 Since v1.0.0
 
@@ -86,7 +83,7 @@ declare const details: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L89)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L75)
 
 Since v1.0.0
 
@@ -124,7 +121,7 @@ declare const downloadToDisk: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L313)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L299)
 
 Since v1.0.0
 
@@ -158,7 +155,7 @@ declare const downloadToStreams: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L208)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L194)
 
 Since v1.0.0
 
@@ -177,32 +174,6 @@ declare const purchase: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L142)
-
-Since v1.0.0
-
-# Device
-
-## AndroidDevice
-
-**Signature**
-
-```ts
-declare const AndroidDevice: typeof AndroidDevice
-```
-
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L76)
-
-Since v1.0.0
-
-## AndroidDeviceService
-
-**Signature**
-
-```ts
-declare const AndroidDeviceService: typeof AndroidDeviceService
-```
-
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L82)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L128)
 
 Since v1.0.0

--- a/docs/gplayapi/PlayAccount.ts.md
+++ b/docs/gplayapi/PlayAccount.ts.md
@@ -1,6 +1,6 @@
 ---
 title: PlayAccount.ts
-nav_order: 3
+nav_order: 4
 parent: "@efffrida/gplayapi"
 ---
 

--- a/docs/gplayapi/index.ts.md
+++ b/docs/gplayapi/index.ts.md
@@ -1,13 +1,12 @@
 ---
 title: index.ts
-nav_order: 2
+nav_order: 3
 parent: "@efffrida/gplayapi"
 ---
 
 ## index.ts overview
 
-Unofficial Google Play Store API for downloading APKs directly from Google
-Play Store.
+Google play android device profiles.
 
 Since v1.0.0
 
@@ -16,12 +15,27 @@ Since v1.0.0
 ## Exports Grouped by Category
 
 - [utils](#utils)
+  - [AndroidDevice (namespace export)](#androiddevice-namespace-export)
   - [GooglePlayApi (namespace export)](#googleplayapi-namespace-export)
   - [PlayAccount (namespace export)](#playaccount-namespace-export)
 
 ---
 
 # utils
+
+## AndroidDevice (namespace export)
+
+Re-exports all named exports from the "./AndroidDevice.ts" module as `AndroidDevice`.
+
+**Signature**
+
+```ts
+export * as AndroidDevice from "./AndroidDevice.ts"
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L10)
+
+Since v1.0.0
 
 ## GooglePlayApi (namespace export)
 
@@ -33,7 +47,7 @@ Re-exports all named exports from the "./GooglePlayApi.ts" module as `GooglePlay
 export * as GooglePlayApi from "./GooglePlayApi.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L18)
 
 Since v1.0.0
 
@@ -47,6 +61,6 @@ Re-exports all named exports from the "./PlayAccount.ts" module as `PlayAccount`
 export * as PlayAccount from "./PlayAccount.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L18)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L25)
 
 Since v1.0.0

--- a/packages/gplayapi/docs/modules/AndroidDevice.ts.md
+++ b/packages/gplayapi/docs/modules/AndroidDevice.ts.md
@@ -16,6 +16,8 @@ Since v1.0.0
 
 - [Constants](#constants)
   - [authHeadersTtl](#authheadersttl)
+- [Layers](#layers)
+  - [EmbeddedPixel7aLive](#embeddedpixel7alive)
 - [Models](#models)
   - [AndroidDevice (class)](#androiddevice-class)
     - [authHeaders (property)](#authheaders-property)
@@ -39,6 +41,24 @@ declare const authHeadersTtl: Duration.Duration
 ```
 
 [Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L55)
+
+Since v1.0.0
+
+# Layers
+
+## EmbeddedPixel7aLive
+
+**Signature**
+
+```ts
+declare const EmbeddedPixel7aLive: Layer.Layer<
+  AndroidDeviceService,
+  Schema.SchemaError | PlatformError.PlatformError | PlatformError.BadArgument,
+  FileSystem.FileSystem | Path.Path
+>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L202)
 
 Since v1.0.0
 
@@ -66,7 +86,7 @@ Since v1.0.0
 readonly authHeaders: Effect.Effect<Record<string, string>, HttpClientError.HttpClientError | Schema.SchemaError | PlayAccountError, PlayAccount | HttpClient.HttpClient>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L176)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L170)
 
 Since v1.0.0
 

--- a/packages/gplayapi/docs/modules/AndroidDevice.ts.md
+++ b/packages/gplayapi/docs/modules/AndroidDevice.ts.md
@@ -1,0 +1,85 @@
+---
+title: AndroidDevice.ts
+nav_order: 1
+parent: Modules
+---
+
+## AndroidDevice.ts overview
+
+Google play android device profiles.
+
+Since v1.0.0
+
+---
+
+## Exports Grouped by Category
+
+- [Constants](#constants)
+  - [authHeadersTtl](#authheadersttl)
+- [Models](#models)
+  - [AndroidDevice (class)](#androiddevice-class)
+    - [authHeaders (property)](#authheaders-property)
+- [Tags](#tags)
+  - [AndroidDeviceService (class)](#androiddeviceservice-class)
+
+---
+
+# Constants
+
+## authHeadersTtl
+
+How long resolved auth headers stay usable. Google's oauth tokens live for an
+hour, so re-acquiring well inside that window keeps a long lived process from
+ever reaching for headers that expired underneath it.
+
+**Signature**
+
+```ts
+declare const authHeadersTtl: Duration.Duration
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L55)
+
+Since v1.0.0
+
+# Models
+
+## AndroidDevice (class)
+
+The profile of the android device that google play requests are made as.
+
+**Signature**
+
+```ts
+declare class AndroidDevice
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L63)
+
+Since v1.0.0
+
+### authHeaders (property)
+
+**Signature**
+
+```ts
+readonly authHeaders: Effect.Effect<Record<string, string>, HttpClientError.HttpClientError | Schema.SchemaError | PlayAccountError, PlayAccount | HttpClient.HttpClient>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L176)
+
+Since v1.0.0
+
+# Tags
+
+## AndroidDeviceService (class)
+
+**Signature**
+
+```ts
+declare class AndroidDeviceService
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L43)
+
+Since v1.0.0

--- a/packages/gplayapi/docs/modules/AndroidDevice.ts.md
+++ b/packages/gplayapi/docs/modules/AndroidDevice.ts.md
@@ -16,6 +16,9 @@ Since v1.0.0
 
 - [Constants](#constants)
   - [authHeadersTtl](#authheadersttl)
+- [Constructors](#constructors)
+  - [EmbeddedPixel7a](#embeddedpixel7a)
+  - [fromPropertiesFile](#frompropertiesfile)
 - [Layers](#layers)
   - [EmbeddedPixel7aLive](#embeddedpixel7alive)
 - [Models](#models)
@@ -44,6 +47,38 @@ declare const authHeadersTtl: Duration.Duration
 
 Since v1.0.0
 
+# Constructors
+
+## EmbeddedPixel7a
+
+**Signature**
+
+```ts
+declare const EmbeddedPixel7a: Effect.Effect<
+  AndroidDevice,
+  Schema.SchemaError | PlatformError.PlatformError | PlatformError.BadArgument,
+  FileSystem.FileSystem | Path.Path
+>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L193)
+
+Since v1.0.0
+
+## fromPropertiesFile
+
+**Signature**
+
+```ts
+declare const fromPropertiesFile: (
+  file: string
+) => Effect.Effect<AndroidDevice, Schema.SchemaError | PlatformError.PlatformError, FileSystem.FileSystem>
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L167)
+
+Since v1.0.0
+
 # Layers
 
 ## EmbeddedPixel7aLive
@@ -58,7 +93,7 @@ declare const EmbeddedPixel7aLive: Layer.Layer<
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L202)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L206)
 
 Since v1.0.0
 
@@ -86,7 +121,7 @@ Since v1.0.0
 readonly authHeaders: Effect.Effect<Record<string, string>, HttpClientError.HttpClientError | Schema.SchemaError | PlayAccountError, PlayAccount | HttpClient.HttpClient>
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L170)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/AndroidDevice.ts#L135)
 
 Since v1.0.0
 

--- a/packages/gplayapi/docs/modules/GooglePlayApi.ts.md
+++ b/packages/gplayapi/docs/modules/GooglePlayApi.ts.md
@@ -1,6 +1,6 @@
 ---
 title: GooglePlayApi.ts
-nav_order: 1
+nav_order: 2
 parent: Modules
 ---
 
@@ -22,9 +22,6 @@ Since v1.0.0
   - [downloadToDisk](#downloadtodisk)
   - [downloadToStreams](#downloadtostreams)
   - [purchase](#purchase)
-- [Device](#device)
-  - [AndroidDevice](#androiddevice)
-  - [AndroidDeviceService](#androiddeviceservice)
 
 ---
 
@@ -44,7 +41,7 @@ declare const bulkDetails: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L113)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L99)
 
 Since v1.0.0
 
@@ -68,7 +65,7 @@ declare const delivery: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L172)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L158)
 
 Since v1.0.0
 
@@ -86,7 +83,7 @@ declare const details: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L89)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L75)
 
 Since v1.0.0
 
@@ -124,7 +121,7 @@ declare const downloadToDisk: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L313)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L299)
 
 Since v1.0.0
 
@@ -158,7 +155,7 @@ declare const downloadToStreams: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L208)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L194)
 
 Since v1.0.0
 
@@ -177,32 +174,6 @@ declare const purchase: (
 >
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L142)
-
-Since v1.0.0
-
-# Device
-
-## AndroidDevice
-
-**Signature**
-
-```ts
-declare const AndroidDevice: typeof AndroidDevice
-```
-
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L76)
-
-Since v1.0.0
-
-## AndroidDeviceService
-
-**Signature**
-
-```ts
-declare const AndroidDeviceService: typeof AndroidDeviceService
-```
-
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L82)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/GooglePlayApi.ts#L128)
 
 Since v1.0.0

--- a/packages/gplayapi/docs/modules/PlayAccount.ts.md
+++ b/packages/gplayapi/docs/modules/PlayAccount.ts.md
@@ -1,6 +1,6 @@
 ---
 title: PlayAccount.ts
-nav_order: 3
+nav_order: 4
 parent: Modules
 ---
 

--- a/packages/gplayapi/docs/modules/index.ts.md
+++ b/packages/gplayapi/docs/modules/index.ts.md
@@ -1,13 +1,12 @@
 ---
 title: index.ts
-nav_order: 2
+nav_order: 3
 parent: Modules
 ---
 
 ## index.ts overview
 
-Unofficial Google Play Store API for downloading APKs directly from Google
-Play Store.
+Google play android device profiles.
 
 Since v1.0.0
 
@@ -16,12 +15,27 @@ Since v1.0.0
 ## Exports Grouped by Category
 
 - [utils](#utils)
+  - [AndroidDevice (namespace export)](#androiddevice-namespace-export)
   - [GooglePlayApi (namespace export)](#googleplayapi-namespace-export)
   - [PlayAccount (namespace export)](#playaccount-namespace-export)
 
 ---
 
 # utils
+
+## AndroidDevice (namespace export)
+
+Re-exports all named exports from the "./AndroidDevice.ts" module as `AndroidDevice`.
+
+**Signature**
+
+```ts
+export * as AndroidDevice from "./AndroidDevice.ts"
+```
+
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L10)
+
+Since v1.0.0
 
 ## GooglePlayApi (namespace export)
 
@@ -33,7 +47,7 @@ Re-exports all named exports from the "./GooglePlayApi.ts" module as `GooglePlay
 export * as GooglePlayApi from "./GooglePlayApi.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L11)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L18)
 
 Since v1.0.0
 
@@ -47,6 +61,6 @@ Re-exports all named exports from the "./PlayAccount.ts" module as `PlayAccount`
 export * as PlayAccount from "./PlayAccount.ts"
 ```
 
-[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L18)
+[Source](https://github.com/leonitousconforti/efffrida/blob/main/packages/gplayapi/src/index.ts#L25)
 
 Since v1.0.0

--- a/packages/gplayapi/src/AndroidDevice.ts
+++ b/packages/gplayapi/src/AndroidDevice.ts
@@ -139,12 +139,6 @@ export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")(
 
     /**
      * @since 1.0.0
-     * @category Layers
-     */
-    public static EmbeddedPixel7aLive = Layer.effect(AndroidDeviceService, AndroidDevice.EmbeddedPixel7a);
-
-    /**
-     * @since 1.0.0
      * @category Destructors
      */
     public get userAgent(): string {
@@ -200,3 +194,13 @@ export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")(
         this.authHeadersCache = undefined;
     }
 }
+
+/**
+ * @since 1.0.0
+ * @category Layers
+ */
+export const EmbeddedPixel7aLive: Layer.Layer<
+    AndroidDeviceService,
+    Schema.SchemaError | PlatformError.BadArgument | PlatformError.PlatformError,
+    Path.Path | FileSystem.FileSystem
+> = Layer.effect(AndroidDeviceService, AndroidDevice.EmbeddedPixel7a);

--- a/packages/gplayapi/src/AndroidDevice.ts
+++ b/packages/gplayapi/src/AndroidDevice.ts
@@ -1,3 +1,9 @@
+/**
+ * Google play android device profiles.
+ *
+ * @since 1.0.0
+ */
+
 import type * as PlatformError from "effect/PlatformError";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import type * as HttpClientError from "effect/unstable/http/HttpClientError";
@@ -13,30 +19,47 @@ import * as Schema from "effect/Schema";
 import * as SchemaGetter from "effect/SchemaGetter";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 
-import type { PlayAccount, PlayAccountError } from "../PlayAccount.ts";
+import type { PlayAccount, PlayAccountError } from "./PlayAccount.ts";
 
-import * as internalAuth from "./auth.ts";
+import * as internalAuth from "./internal/auth.ts";
 
-export const StringArrayFromString = Schema.suspend(() => {
+/** @internal */
+const StringArrayFromString = Schema.suspend(() => {
     const splitter = SchemaGetter.split({ separator: "," });
     const joiner = SchemaGetter.transform((arr: ReadonlyArray<string>) => arr.join(","));
     const transform = SchemaTransformation.make({ encode: joiner, decode: splitter });
     return Schema.String.pipe(Schema.decodeTo(Schema.Array(Schema.String), transform));
 });
 
-export const BooleanFromString = Schema.Literals(["true", "false"])
+/** @internal */
+const BooleanFromString = Schema.Literals(["true", "false"])
     .transform([true, false])
     .pipe(Schema.decodeTo(Schema.Boolean));
 
-export class Service extends Context.Service<Service, AndroidDevice>()("@efffrida/gplayapi/device") {}
+/**
+ * @since 1.0.0
+ * @category Tags
+ */
+export class AndroidDeviceService extends Context.Service<AndroidDeviceService, AndroidDevice>()(
+    "@efffrida/gplayapi/AndroidDevice"
+) {}
 
 /**
  * How long resolved auth headers stay usable. Google's oauth tokens live for an
  * hour, so re-acquiring well inside that window keeps a long lived process from
  * ever reaching for headers that expired underneath it.
+ *
+ * @since 1.0.0
+ * @category Constants
  */
 export const authHeadersTtl: Duration.Duration = Duration.minutes(30);
 
+/**
+ * The profile of the android device that google play requests are made as.
+ *
+ * @since 1.0.0
+ * @category Models
+ */
 export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")({
     UserReadableName: Schema.String,
     "Build.BOOTLOADER": Schema.String,
@@ -79,6 +102,10 @@ export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")(
     private authHeadersCache?: { readonly headers: Record<string, string>; readonly expiresAt: number } | undefined =
         undefined;
 
+    /**
+     * @since 1.0.0
+     * @category Constructors
+     */
     public static fromPropertiesFile = Effect.fnUntraced(function* (
         file: string
     ): Effect.fn.Return<AndroidDevice, Schema.SchemaError | PlatformError.PlatformError, FileSystem.FileSystem> {
@@ -101,13 +128,25 @@ export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")(
         return yield* decodeDevice(properties);
     });
 
+    /**
+     * @since 1.0.0
+     * @category Constructors
+     */
     public static EmbeddedPixel7a = Path.Path.pipe(
-        Effect.flatMap((path) => path.fromFileUrl(new URL("../../devices/arm64_xxhdpi.properties", import.meta.url))),
+        Effect.flatMap((path) => path.fromFileUrl(new URL("../devices/arm64_xxhdpi.properties", import.meta.url))),
         Effect.flatMap(AndroidDevice.fromPropertiesFile)
     );
 
-    public static EmbeddedPixel7aLive = Layer.effect(Service, AndroidDevice.EmbeddedPixel7a);
+    /**
+     * @since 1.0.0
+     * @category Layers
+     */
+    public static EmbeddedPixel7aLive = Layer.effect(AndroidDeviceService, AndroidDevice.EmbeddedPixel7a);
 
+    /**
+     * @since 1.0.0
+     * @category Destructors
+     */
     public get userAgent(): string {
         const deviceProperties = {
             api: 3,
@@ -130,6 +169,10 @@ export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")(
         return `Android-Finsky/${this["Vending.versionString"]} (${devicePropertiesString})`;
     }
 
+    /**
+     * @since 1.0.0
+     * @category Destructors
+     */
     public readonly authHeaders: Effect.Effect<
         Record<string, string>,
         HttpClientError.HttpClientError | Schema.SchemaError | PlayAccountError,

--- a/packages/gplayapi/src/AndroidDevice.ts
+++ b/packages/gplayapi/src/AndroidDevice.ts
@@ -104,41 +104,6 @@ export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")(
 
     /**
      * @since 1.0.0
-     * @category Constructors
-     */
-    public static fromPropertiesFile = Effect.fnUntraced(function* (
-        file: string
-    ): Effect.fn.Return<AndroidDevice, Schema.SchemaError | PlatformError.PlatformError, FileSystem.FileSystem> {
-        const decodeDevice = Schema.decodeUnknownEffect(AndroidDevice);
-        const decodePropertiesFile = Schema.decodeEffect(
-            Schema.String.pipe(
-                Schema.decodeTo(
-                    Schema.Record(Schema.String, Schema.String),
-                    SchemaTransformation.splitKeyValue({
-                        keyValueSeparator: "=",
-                        separator: "\n",
-                    })
-                )
-            )
-        );
-
-        const fileSystem = yield* FileSystem.FileSystem;
-        const content = yield* fileSystem.readFileString(file);
-        const properties = yield* decodePropertiesFile(content);
-        return yield* decodeDevice(properties);
-    });
-
-    /**
-     * @since 1.0.0
-     * @category Constructors
-     */
-    public static EmbeddedPixel7a = Path.Path.pipe(
-        Effect.flatMap((path) => path.fromFileUrl(new URL("../devices/arm64_xxhdpi.properties", import.meta.url))),
-        Effect.flatMap(AndroidDevice.fromPropertiesFile)
-    );
-
-    /**
-     * @since 1.0.0
      * @category Destructors
      */
     public get userAgent(): string {
@@ -197,10 +162,49 @@ export class AndroidDevice extends Schema.Class<AndroidDevice>("AndroidDevice")(
 
 /**
  * @since 1.0.0
+ * @category Constructors
+ */
+export const fromPropertiesFile = Effect.fnUntraced(function* (
+    file: string
+): Effect.fn.Return<AndroidDevice, Schema.SchemaError | PlatformError.PlatformError, FileSystem.FileSystem> {
+    const decodeDevice = Schema.decodeUnknownEffect(AndroidDevice);
+    const decodePropertiesFile = Schema.decodeEffect(
+        Schema.String.pipe(
+            Schema.decodeTo(
+                Schema.Record(Schema.String, Schema.String),
+                SchemaTransformation.splitKeyValue({
+                    keyValueSeparator: "=",
+                    separator: "\n",
+                })
+            )
+        )
+    );
+
+    const fileSystem = yield* FileSystem.FileSystem;
+    const content = yield* fileSystem.readFileString(file);
+    const properties = yield* decodePropertiesFile(content);
+    return yield* decodeDevice(properties);
+});
+
+/**
+ * @since 1.0.0
+ * @category Constructors
+ */
+export const EmbeddedPixel7a: Effect.Effect<
+    AndroidDevice,
+    Schema.SchemaError | PlatformError.BadArgument | PlatformError.PlatformError,
+    Path.Path | FileSystem.FileSystem
+> = Path.Path.pipe(
+    Effect.flatMap((path) => path.fromFileUrl(new URL("../devices/arm64_xxhdpi.properties", import.meta.url))),
+    Effect.flatMap(fromPropertiesFile)
+);
+
+/**
+ * @since 1.0.0
  * @category Layers
  */
 export const EmbeddedPixel7aLive: Layer.Layer<
     AndroidDeviceService,
     Schema.SchemaError | PlatformError.BadArgument | PlatformError.PlatformError,
     Path.Path | FileSystem.FileSystem
-> = Layer.effect(AndroidDeviceService, AndroidDevice.EmbeddedPixel7a);
+> = Layer.effect(AndroidDeviceService, EmbeddedPixel7a);

--- a/packages/gplayapi/src/GooglePlayApi.ts
+++ b/packages/gplayapi/src/GooglePlayApi.ts
@@ -23,6 +23,7 @@ import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 
 import type { PlayAccount, PlayAccountError } from "./PlayAccount.ts";
 
+import { type AndroidDevice, AndroidDeviceService } from "./AndroidDevice.ts";
 import {
     BulkDetailsRequestSchema,
     type BulkDetailsResponse,
@@ -30,7 +31,6 @@ import {
     type DeliveryResponse,
     type DetailsResponse,
 } from "./generated/GooglePlay_pb.ts";
-import { type AndroidDevice, Service as AndroidDeviceService } from "./internal/device.ts";
 import { decodeResponseFromResponseWrapper, encodeRequest } from "./internal/http.ts";
 
 /** @internal */
@@ -67,20 +67,6 @@ const evictRejectedAuthHeaders =
                 })
             );
         });
-
-export {
-    /**
-     * @since 1.0.0
-     * @category Device
-     */
-    AndroidDevice,
-
-    /**
-     * @since 1.0.0
-     * @category Device
-     */
-    Service as AndroidDeviceService,
-} from "./internal/device.ts";
 
 /**
  * @since 1.0.0

--- a/packages/gplayapi/src/index.ts
+++ b/packages/gplayapi/src/index.ts
@@ -3,6 +3,13 @@
  */
 
 /**
+ * Google play android device profiles.
+ *
+ * @since 1.0.0
+ */
+export * as AndroidDevice from "./AndroidDevice.ts"
+
+/**
  * Unofficial Google Play Store API for downloading APKs directly from Google
  * Play Store.
  *

--- a/packages/gplayapi/src/internal/auth.ts
+++ b/packages/gplayapi/src/internal/auth.ts
@@ -8,7 +8,7 @@ import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 
-import type { AndroidDevice } from "./device.ts";
+import type { AndroidDevice } from "../AndroidDevice.ts";
 
 import {
     AndroidCheckinRequestSchema,

--- a/scratchpad/playground.ts
+++ b/scratchpad/playground.ts
@@ -51,7 +51,7 @@ const DeviceLive = pipe(
             Effect.asVoid
         )
     ),
-    Layer.provide(AndroidDevice.AndroidDevice.EmbeddedPixel7aLive),
+    Layer.provide(AndroidDevice.EmbeddedPixel7aLive),
     Layer.provide(NodeHttpClient.layerFetch),
     Layer.provide(NodeServices.layer)
 );

--- a/scratchpad/playground.ts
+++ b/scratchpad/playground.ts
@@ -3,7 +3,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { NodeServices, NodeRuntime, NodeHttpClient } from "@effect/platform-node";
 import { FridaDevice, FridaDeviceAcquisitionError, FridaScript, FridaSession } from "@efffrida/frida-tools";
-import { GooglePlayApi } from "@efffrida/gplayapi";
+import { AndroidDevice, GooglePlayApi } from "@efffrida/gplayapi";
 
 const DeviceLive = pipe(
     FridaDevice.layerAndroidEmulatorDeviceConfig("Small_Phone", {
@@ -51,7 +51,7 @@ const DeviceLive = pipe(
             Effect.asVoid
         )
     ),
-    Layer.provide(GooglePlayApi.AndroidDevice.EmbeddedPixel7aLive),
+    Layer.provide(AndroidDevice.AndroidDevice.EmbeddedPixel7aLive),
     Layer.provide(NodeHttpClient.layerFetch),
     Layer.provide(NodeServices.layer)
 );


### PR DESCRIPTION
Moves `AndroidDevice` from `src/internal/device.ts` into its own top-level `AndroidDevice` module, mirroring the `PlayAccount` breakout in #186.

- New `AndroidDevice` module exports the `AndroidDevice` schema class, the `AndroidDeviceService` tag, `fromPropertiesFile`, `EmbeddedPixel7a`, the `EmbeddedPixel7aLive` layer, and `authHeadersTtl`, all with docgen annotations
- The former statics on the `AndroidDevice` class (`fromPropertiesFile`, `EmbeddedPixel7a`, `EmbeddedPixel7aLive`) are now top level exports of the module
- `GooglePlayApi` no longer re-exports `AndroidDevice`/`AndroidDeviceService`; import them from the new module or the package index instead (breaking, noted in the changeset)
- Tag identifier renamed from `@efffrida/gplayapi/device` to `@efffrida/gplayapi/AndroidDevice`
- Regenerated `src/index.ts` (codegen) and docs (docgen), updated `scratchpad/playground.ts`